### PR TITLE
Additional tags for common uploads (for lethal-company.yml)

### DIFF
--- a/games/data/lethal-company.yml
+++ b/games/data/lethal-company.yml
@@ -25,6 +25,12 @@ thunderstore:
       label: "MelonLoader"
     suits:
       label: "Suits"
+    boombox:
+      label: "Boombox Music"
+    video:
+      label: "TV Videos"
+    poster:
+      label: "Posters"
     equipment:
       label: "Equipment"
     items:


### PR DESCRIPTION
Added tags for custom boombox music, custom TV videos, and custom ship poster images.

Granted, there's no guarantee people will use them, but there needs to be some kind of progress made on the issue of all the incorrect tagging going on in the Lethal Company mods list.