### PR TITLE
Update tags for Risk of Rain Returns

### DIFF
--- a/games/data/risk-of-rain-returns.yml
+++ b/games/data/risk-of-rain-returns.yml
@@ -15,10 +15,40 @@ thunderstore:
       label: "Tools"
     libraries:
       label: "Libraries"
+    quality-of-life:
+      label: "Quality of Life"
+    gameplay-tweaks:
+      label: "Gameplay Tweaks"
+    items:
+      label: "Items"
+    survivors:
+      label: "Survivors"
+    skills:
+      label: "Skills"
+    skins:
+      label: "Skins"
+    monsters:
+      label: "Monsters"
+    elites:
+      label: "Elites"
+    stages:
+      label: "Stages"
+    interactables:
+      label: "Interactables"
+    artifacts:
+      label: "Artifacts"
+    gamemodes:
+      label: "Gamemodes"
     misc:
       label: "Misc"
+    language:
+      label: "Language"
     audio:
       label: "Audio"
+    client-side:
+      label: "Client-side"
+    server-side:
+      label: "Server-side"
   sections:
     mods:
       name: "Mods"


### PR DESCRIPTION
Added 15 game-specific tags:

`Quality of Life`
`Gameplay Tweaks`
`Items`
`Survivors`
`Skills`
`Skins`
`Monsters`
`Elites`
`Stages`
`Interactables`
`Artifacts`
`Gamemodes`
`Language`
`Client-side`
`Server-side`

Ideally the `Misc` tag would be removed but I was told this is currently unsupported