### PR TITLE
Fixed Broken Discord Invite Link For Atomicrops

### DIFF
--- a/games/data/atomicrops.yml
+++ b/games/data/atomicrops.yml
@@ -28,4 +28,4 @@ thunderstore:
       name: "Modpacks"
       requireCategories:
         - "modpacks"
-  discordUrl: "https://discord.gg/4G3sfhYp"
+  discordUrl: "https://discord.gg/aN6zmqABaF"


### PR DESCRIPTION
Atomicrops discord link was expired. Found the discord from an official post [here](https://www.reddit.com/r/Atomicrops/comments/15yiip3/atomicrops_modding/).