### PR TITLE
Added autolistPackageIds

### DIFF
--- a/games/src/models.ts
+++ b/games/src/models.ts
@@ -61,6 +61,7 @@ export interface ThunderstoreCommunityDefinition {
   };
   discordUrl?: string;
   wikiUrl?: string;
+  autolistPackageIds?: string[];
 }
 
 export interface GameDefinition {

--- a/games/src/schema/autolistPackages.ts
+++ b/games/src/schema/autolistPackages.ts
@@ -1,0 +1,24 @@
+export const AUTOLIST_PACKAGE_CHOICES = [
+  {
+    value: "BepInEx-BepInExPack",
+    name: "BepInEx 5 (use this for Unity mono games)",
+  },
+  {
+    value: "BepInEx-BepInExPack_IL2CPP",
+    name: "BepInEx 6 IL2CPP (use this for Unity IL2CPP games)",
+  },
+  {
+    value: "Thunderstore-unreal_shimloader",
+    name: "Unreal Engine shimloader",
+  },
+  {
+    value: "LavaGang-MelonLoader",
+    name: "MelonLoader",
+  },
+];
+
+const AUTOLIST_PACKAGE_IDS = AUTOLIST_PACKAGE_CHOICES.map((x) => x.value);
+
+export function isAutolistPackageValid(autolistPackageId: string): boolean {
+  return AUTOLIST_PACKAGE_IDS.indexOf(autolistPackageId) > -1;
+}

--- a/games/src/schema/validator.ts
+++ b/games/src/schema/validator.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isAutolistPackageValid } from "./autolistPackages";
 
 const slug = z.string().regex(new RegExp(/^[a-z0-9](-?[a-z0-9])*$/));
 
@@ -20,6 +21,7 @@ const communitySchema = z.strictObject({
   ),
   wikiUrl: z.string().optional(),
   discordUrl: z.string().optional(),
+  autolistPackageIds: z.array(z.string()).optional(),
 });
 
 export type CommunitySchemaType = z.infer<typeof communitySchema>;
@@ -94,6 +96,16 @@ export function validateSchemaJson(schemaJson: any): SchemaType {
           `to use the label '${key}' but found '${game.label}'`
       );
     }
+  });
+
+  Object.entries(parsed.communities).forEach(([key, community]) => {
+    (community.autolistPackageIds ?? []).forEach((packageId) => {
+      if (!isAutolistPackageValid(packageId)) {
+        throw new Error(
+          `Invalid autolist package ID "${packageId}" defined for community "${key}"`
+        );
+      }
+    });
   });
 
   return parsed;

--- a/games/src/scripts/add.ts
+++ b/games/src/scripts/add.ts
@@ -2,8 +2,9 @@ import { GameDefinition } from "../models";
 import { v4 as uuid } from "uuid";
 import fs from "fs";
 import * as yaml from "js-yaml";
-import { input } from "@inquirer/prompts";
+import { input, checkbox } from "@inquirer/prompts";
 import _ from "lodash";
+import { AUTOLIST_PACKAGE_CHOICES } from "../schema/autolistPackages";
 
 const displayName = await input({
   message: "Display name for the community",
@@ -21,6 +22,11 @@ const discordUrl = await input({
 const wikiUrl = await input({
   message: "Wiki URL for the community (optional)",
   default: "",
+});
+
+const autolistPackageIds = await checkbox({
+  message: "Automatically list package",
+  choices: AUTOLIST_PACKAGE_CHOICES,
 });
 
 const game: GameDefinition = {
@@ -68,6 +74,7 @@ const game: GameDefinition = {
     },
     wikiUrl: wikiUrl || undefined,
     discordUrl: discordUrl || undefined,
+    autolistPackageIds: autolistPackageIds || undefined,
   },
 };
 


### PR DESCRIPTION
The community schema now supports the autolistPackageIds field, which can be used to specify packages that should be listed automatically in a community when the schema syncs.

https://github.com/thunderstore-io/Thunderstore/pull/1039 should likely be accepted first.