### PR TITLE
lethal-company: Added categories for the latest two versions

### DIFF
--- a/games/data/lethal-company.yml
+++ b/games/data/lethal-company.yml
@@ -65,10 +65,10 @@ thunderstore:
       label: "Performance"
     tweaks-and-quality-of-life:
       label: "Tweaks & Quality Of Life"
-    v50:
-      label: "v50"
     v56:
       label: "v56"
+    v60:
+      label: "v60"
   sections:
     mods:
       name: "Mods"

--- a/games/data/lethal-company.yml
+++ b/games/data/lethal-company.yml
@@ -65,6 +65,10 @@ thunderstore:
       label: "Performance"
     tweaks-and-quality-of-life:
       label: "Tweaks & Quality Of Life"
+    v50:
+      label: "v50"
+    v56:
+      label: "v56"
   sections:
     mods:
       name: "Mods"


### PR DESCRIPTION
Added categories for the latest two versions of lethal company (v56 & v60) to make it easier for people to know which mods still work.