### PR TITLE
Autolist BepInEx for A&T Tavern, Goodbye Volcano High, Screw Drivers

### DIFF
--- a/games/data/ale-and-tale-tavern.yml
+++ b/games/data/ale-and-tale-tavern.yml
@@ -29,3 +29,4 @@ thunderstore:
       requireCategories:
         - "modpacks"
   discordUrl: "https://discord.com/invite/qqxmSC8B5J"
+  autolistPackageIds: ["BepInEx-BepInExPack"]

--- a/games/data/goodbye-volcano-high.yml
+++ b/games/data/goodbye-volcano-high.yml
@@ -29,3 +29,4 @@ thunderstore:
       requireCategories:
         - "modpacks"
   discordUrl: "http://discord.gg/ko-op"
+  autolistPackageIds: ["BepInEx-BepInExPack"]

--- a/games/data/screw-drivers.yml
+++ b/games/data/screw-drivers.yml
@@ -29,3 +29,4 @@ thunderstore:
       requireCategories:
         - "modpacks"
   discordUrl: "https://discord.gg/screwdrivers"
+  autolistPackageIds: ["BepInEx-BepInExPack"]


### PR DESCRIPTION
According to the original game requests posts, all three use Mono, so they all get the v5 of BepInEx.