### PR TITLE
Add WEBFISHING

### DIFF
--- a/games/data/webfishing.yml
+++ b/games/data/webfishing.yml
@@ -1,0 +1,25 @@
+uuid: "0cfe33bd-9fb6-4d50-899f-9daa9ef16fc0"
+label: "webfishing"
+meta:
+  displayName: "WEBFISHING"
+  iconUrl: "None"
+distributions: []
+thunderstore:
+  displayName: "WEBFISHING"
+  categories:
+    mods:
+      label: "Mods"
+    cosmetics:
+      label: "Cosmetics"
+    tools:
+      label: "Tools"
+    libraries:
+      label: "Libraries"
+    misc:
+      label: "Misc"
+  sections:
+    mods:
+      name: "Mods"
+  wikiUrl: "https://webfishing.wiki.gg/wiki/WEBFISHING_Wiki"
+  discordUrl: "https://discord.gg/HzhCPxeCKY"
+  autolistPackageIds: []


### PR DESCRIPTION
## Game info

[Steam page](https://store.steampowered.com/app/3146520/WEBFISHING/). Godot 3.5.2 (with GodotSteam). "Popular indie game" syndrome (12,858 playing as of writing, via SteamDB). Community is rapidly growing in size.

## Technical info

WEBFISHING is Godot, but Godot mod loaders are not mature. I developed a mod loader from scratch for WEBFISHING named [GDWeave](https://github.com/NotNite/GDWeave). It targets only Godot 3.5.2 but will eventually branch out to other engine versions.

The community currently uses [Hook, Line, & Sinker](https://hooklinesinker.lol/) by @pyoidzzz, which will be updated to use the Thunderstore API when this PR is merged.

GDWeave is not supported in the Thunderstore App or r2modman - I am happy to help add support to both. It is similar to BepInEx install structure wise (GDWeave/mods/<mod id> folder - holds a manifest JSON, pack file, C# assembly).

GDWeave should be published to Thunderstore, preferably as cross-community in the event other communities want to make use of it, but it is not required. I have preparations for that [here](https://github.com/NotNite/GDWeave/tree/thunderstore) (just needs a tcli thunderstore.toml written), but it's not important because HLS can manage GDWeave automatically. GDWeave uses Reloaded libraries for hooking and signature scanning and will likely trip Thunderstore anti-spam if it is published.

Because of HLS already existing, **GDWeave being published and support for it in the Thunderstore App is not a blocker.** We already have mod managers and this can be a secondary priority.

## Community info

The wiki and Discord is unofficial. The Discord server is owned by @pyoidzzz.

We currently use [a custom static site](https://github.com/NotNite/webfishing-mods) for mod listing. Moving to Thunderstore will require updating HLS to use the Thunderstore API and sunsetting this website (which I am in charge of).

## PR info

Requested in Thunderstore Discord [here](https://discord.com/channels/809128887366975518/1300648467256836116). The post mentions the GDScript Mod Loader, but the community does not use this and there are no mods using that mod loader.

YAML was generated and hand-edited with the provided TypeScript code. "Modpacks" are not included because the mod loader doesn't know how to handle them properly (and I fundamentally disagree with the concept of using Thunderstore for such a thing). "Cosmetics" were added because a large majority of the community is focused on cosmetic mods at the moment.

This PR probably won't be accepted, because I have no affiliation with Thunderstore, but it serves as a good place to point about our community info and has a ready-to-go YAML if a Thunderstore admin would like to add it themselves.