### PR TITLE
webfishing: Change wiki URL

### DIFF
--- a/games/data/webfishing.yml
+++ b/games/data/webfishing.yml
@@ -28,6 +28,6 @@ thunderstore:
     maps:
       label: "Maps"
   sections: {}
-  wikiUrl: "https://webfishing.wiki.gg/wiki/WEBFISHING_Wiki"
+  wikiUrl: "https://notnite.github.io/webfishing-mod-wiki/"
   discordUrl: "https://discord.gg/HzhCPxeCKY"
   autolistPackageIds: []


### PR DESCRIPTION
When submitting the original game entry, I used the community wiki. It then dawned on me as soon as the page went live that this is supposed to be a wiki for *modding*, not for the game itself. 🤦