### PR TITLE
Add ATLYSS

### DIFF
--- a/games/data/atlyss.yml
+++ b/games/data/atlyss.yml
@@ -1,0 +1,33 @@
+uuid: "0b5d044e-7f08-411a-af50-40119a401460"
+label: "atlyss"
+meta:
+  displayName: "ATLYSS"
+  iconUrl: "None"
+distributions: []
+thunderstore:
+  displayName: "ATLYSS"
+  categories:
+    mods:
+      label: "Mods"
+    modpacks:
+      label: "Modpacks"
+    tools:
+      label: "Tools"
+    libraries:
+      label: "Libraries"
+    misc:
+      label: "Misc"
+    audio:
+      label: "Audio"
+  sections:
+    mods:
+      name: "Mods"
+      excludeCategories:
+        - "modpacks"
+    modpacks:
+      name: "Modpacks"
+      requireCategories:
+        - "modpacks"
+  wikiUrl: "https://atlyss.wiki.gg/wiki/ATLYSS_Wiki"
+  discordUrl: "https://discord.gg/atlyss"
+  autolistPackageIds: []


### PR DESCRIPTION
ATLYSS uses Unity v2021.3.16.4200023 with .NET Standard 2.0.
It has just been released and is getting popular pretty fast, so it would be nice to get something going for it on Thunderstore.

[Steam page for Atlyss](https://store.steampowered.com/app/2768430/ATLYSS/)

There is an official Discord server called "KisSoft Underground", but it's in a read-only state, mostly being used for announcements. The game has an official wiki on [wiki.gg](https://atlyss.wiki.gg/wiki/ATLYSS_Wiki). Other than that, there's an unofficial community server and a server for wiki editors.

The YAML was generated using the provided add script.
