### PR TITLE
Fix TSC build and linting

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,26 @@
+on:
+  pull_request:
+
+jobs:
+  deploy:
+    name: "Lint"
+    runs-on: "ubuntu-latest"
+    defaults:
+      run:
+        working-directory: "games"
+    steps:
+      - uses: "actions/checkout@v3"
+        with:
+          submodules: "recursive"
+      - uses: "actions/setup-node@v3"
+        with:
+          node-version: "23.6"
+          cache-dependency-path: |
+            games/yarn.lock
+            games/r2modmanPlus/yarn.lock
+      - name: "Install main dependencies"
+        run: "yarn install --frozen-lockfile"
+      - name: "Install r2modmanPlus dependencies"
+        run: "cd r2modmanPlus && yarn install --frozen-lockfile"
+      - name: "Lint"
+        run: "yarn run lint"

--- a/games/package.json
+++ b/games/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@thunderstore/games",
-  "type": "module",
   "version": "0.1.0",
   "description": "Index of Thunderstore supported games",
   "main": "index.js",
@@ -16,7 +15,8 @@
     "add": "tsx ./src/scripts/add.ts",
     "deploy": "tsx ./src/scripts/deploy.ts",
     "validate": "tsx ./src/scripts/validate.ts",
-    "diff": "tsx ./src/scripts/diff.ts"
+    "diff": "tsx ./src/scripts/diff.ts",
+    "lint": "tsc --noEmit"
   },
   "dependencies": {
     "@inquirer/prompts": "^3.0.1",
@@ -27,10 +27,10 @@
     "js-yaml": "^4.1.0",
     "json-diff-kit": "^1.0.31",
     "lodash": "^4.17.21",
-    "tsx": "^4.7.2",
-    "typescript": "^4.8.3",
+    "tsx": "4.19.3",
+    "typescript": "5.5",
     "uuid": "^9.0.0",
-    "zod": "^3.23.4"
+    "zod": "3.24.2"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.196"

--- a/games/src/load.ts
+++ b/games/src/load.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as yaml from "js-yaml";
-import { GameDefinition, PackageInstallerDefinition } from "./models";
+import { GameDefinition, PackageInstallerDefinition } from "./models.js";
 import { lstatSync } from "fs";
 
 function loadYamlFromDir<T>(path: string) {

--- a/games/src/models.ts
+++ b/games/src/models.ts
@@ -2,8 +2,19 @@ export type ModmanTrackingMethod =
   | "state"
   | "subdir"
   | "subdir-no-flatten"
+  | "package-zip"
   | null;
-export type ModmanPackageLoader = "bepinex" | "melonloader" | "northstar";
+export type ModmanPackageLoader =
+  | "bepinex"
+  | "melonloader"
+  | "northstar"
+  | "godot"
+  | "ancient-dungeon-vr"
+  | "shimloader"
+  | "lovely"
+  | "return-of-modding"
+  | "gdweave"
+  | "melonloader-recursive";
 
 export type DistributionPlatform =
   | "steam"
@@ -39,12 +50,12 @@ export interface GameModmanDefinition {
   dataFolderName: string;
   settingsIdentifier: string;
   packageIndex: string;
-  exclusionsUrl: string;
+  // exclusionsUrl: string;
   steamFolderName: string;
   exeNames: string[];
   gameInstancetype: "game" | "server";
   gameSelectionDisplayMode: "visible" | "hidden";
-  modLoaderPackages: ModmanModLoaderPackage[];
+  // modLoaderPackages: ModmanModLoaderPackage[];
   installRules: ModmanInstallRule[];
   relativeFileExclusions?: string[];
 }

--- a/games/src/schema/builder.ts
+++ b/games/src/schema/builder.ts
@@ -1,9 +1,9 @@
-import { loadGameDefinitions, loadInstallerDefinitions } from "../load";
+import { loadGameDefinitions, loadInstallerDefinitions } from "../load.js";
 import {
   GameDefinition,
   PackageInstallerDefinition,
   ThunderstoreCommunityDefinition,
-} from "../models";
+} from "../models.js";
 import _ from "lodash";
 
 export function buildSchemaJson() {

--- a/games/src/schema/validator.ts
+++ b/games/src/schema/validator.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
-import { isAutolistPackageValid } from "./autolistPackages";
+
+import { isAutolistPackageValid } from "./autolistPackages.js";
 
 const slug = z.string().regex(new RegExp(/^[a-z0-9](-?[a-z0-9])*$/));
 
@@ -26,28 +27,27 @@ const communitySchema = z.strictObject({
 
 export type CommunitySchemaType = z.infer<typeof communitySchema>;
 
-export const ecosystemJsonSchema = z.strictObject({
-  schemaVersion: z.string(),
-  games: z.record(
-    z.string(),
+const gameSchema = z.strictObject({
+  uuid: z.string().uuid(),
+  label: slug,
+  meta: z.strictObject({
+    displayName: z.string(),
+    iconUrl: z.string().nullable(),
+  }),
+  distributions: z.array(
     z.strictObject({
-      uuid: z.string().uuid(),
-      label: slug,
-      meta: z.strictObject({
-        displayName: z.string(),
-        iconUrl: z.string().nullable(),
-      }),
-      distributions: z.array(
-        z.strictObject({
-          platform: z.string(),
-          identifier: z.string().optional().nullable(),
-        })
-      ),
-      thunderstore: communitySchema.optional(),
-      tcli: z.object({}).optional(), // TODO: Use strict object with schema
-      r2modman: z.object({}).optional(), // TODO: Use strict object with schema
+      platform: z.string(),
+      identifier: z.string().optional().nullable(),
     })
   ),
+  thunderstore: communitySchema.optional(),
+  tcli: z.object({}).optional(), // TODO: Use strict object with schema
+  r2modman: z.object({}).optional(), // TODO: Use strict object with schema
+});
+
+export const ecosystemJsonSchema = z.strictObject({
+  schemaVersion: z.string(),
+  games: z.record(z.string(), gameSchema),
   communities: z.record(slug, communitySchema),
   packageInstallers: z.record(
     slug,

--- a/games/src/scripts/add.ts
+++ b/games/src/scripts/add.ts
@@ -1,98 +1,105 @@
-import { GameDefinition } from "../models";
+import { GameDefinition } from "../models.js";
 import { v4 as uuid } from "uuid";
 import fs from "fs";
 import * as yaml from "js-yaml";
 import { input, checkbox } from "@inquirer/prompts";
 import _ from "lodash";
-import { AUTOLIST_PACKAGE_CHOICES } from "../schema/autolistPackages";
+import { AUTOLIST_PACKAGE_CHOICES } from "../schema/autolistPackages.js";
 
-const displayName = await input({
-  message: "Display name for the community",
-  validate: (val) => !!val,
-});
-const identifier = await input({
-  message: "Identifier for the community (slug)",
-  default: _.kebabCase(displayName),
-  validate: (val) => !!val && val == _.kebabCase(val),
-});
-const discordUrl = await input({
-  message: "Discord URL for the community (optional)",
-  default: "",
-});
-const wikiUrl = await input({
-  message: "Wiki URL for the community (optional)",
-  default: "",
-});
+async function runAddCommand() {
+  const displayName = await input({
+    message: "Display name for the community",
+    validate: (val) => !!val,
+  });
+  const identifier = await input({
+    message: "Identifier for the community (slug)",
+    default: _.kebabCase(displayName),
+    validate: (val) => !!val && val == _.kebabCase(val),
+  });
+  const discordUrl = await input({
+    message: "Discord URL for the community (optional)",
+    default: "",
+  });
+  const wikiUrl = await input({
+    message: "Wiki URL for the community (optional)",
+    default: "",
+  });
 
-const autolistPackageIds = await checkbox({
-  message: "Automatically list package",
-  choices: AUTOLIST_PACKAGE_CHOICES,
-});
+  const autolistPackageIds = await checkbox({
+    message: "Automatically list package",
+    choices: AUTOLIST_PACKAGE_CHOICES,
+  });
 
-const shortDescription = await input({
-  message: "Short description for the community (optional)",
-  default: "",
-  validate: (val) => val.length < 513,
-});
+  const shortDescription = await input({
+    message: "Short description for the community (optional)",
+    default: "",
+    validate: (val) => val.length < 513,
+  });
 
-const game: GameDefinition = {
-  uuid: uuid(),
-  label: identifier,
-  meta: {
-    displayName,
-    iconUrl: "None",
-  },
-  distributions: [],
-  // TODO: Enable once consumers implemented
-  // r2modman: {
-  //   internalFolderName: name,
-  //   dataFolderName: name,
-  //   settingsIdentifier: name,
-  //   packageIndex: `https://thunderstore.io/c/${name}/api/v1/package/`,
-  //   exclusionsUrl:
-  //     "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
-  //   steamFolderName: name,
-  //   exeNames: [`${name}.exe`],
-  //   gameInstancetype: "game",
-  //   gameSelectionDisplayMode: "visible",
-  //   modLoaderPackages: [],
-  //   installRules: [],
-  // },
-  thunderstore: {
-    displayName,
-    categories: {
-      mods: { label: "Mods" },
-      modpacks: { label: "Modpacks" },
-      tools: { label: "Tools" },
-      libraries: { label: "Libraries" },
-      misc: { label: "Misc" },
-      audio: { label: "Audio" },
+  const game: GameDefinition = {
+    uuid: uuid(),
+    label: identifier,
+    meta: {
+      displayName,
+      iconUrl: "None",
     },
-    sections: {
-      mods: {
-        name: "Mods",
-        excludeCategories: ["modpacks"],
+    distributions: [],
+    // TODO: Enable once consumers implemented
+    // r2modman: {
+    //   internalFolderName: name,
+    //   dataFolderName: name,
+    //   settingsIdentifier: name,
+    //   packageIndex: `https://thunderstore.io/c/${name}/api/v1/package/`,
+    //   exclusionsUrl:
+    //     "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
+    //   steamFolderName: name,
+    //   exeNames: [`${name}.exe`],
+    //   gameInstancetype: "game",
+    //   gameSelectionDisplayMode: "visible",
+    //   modLoaderPackages: [],
+    //   installRules: [],
+    // },
+    thunderstore: {
+      displayName,
+      categories: {
+        mods: { label: "Mods" },
+        modpacks: { label: "Modpacks" },
+        tools: { label: "Tools" },
+        libraries: { label: "Libraries" },
+        misc: { label: "Misc" },
+        audio: { label: "Audio" },
       },
-      modpacks: {
-        name: "Modpacks",
-        requireCategories: ["modpacks"],
+      sections: {
+        mods: {
+          name: "Mods",
+          excludeCategories: ["modpacks"],
+        },
+        modpacks: {
+          name: "Modpacks",
+          requireCategories: ["modpacks"],
+        },
       },
+      wikiUrl: wikiUrl || undefined,
+      discordUrl: discordUrl || undefined,
+      autolistPackageIds: autolistPackageIds || undefined,
+      shortDescription: shortDescription || undefined,
     },
-    wikiUrl: wikiUrl || undefined,
-    discordUrl: discordUrl || undefined,
-    autolistPackageIds: autolistPackageIds || undefined,
-    shortDescription: shortDescription || undefined,
-  },
-};
+  };
 
-const path = `./data/${identifier}.yml`;
-if (fs.existsSync(path)) {
-  throw new Error(`${path} already exists`);
+  const path = `./data/${identifier}.yml`;
+  if (fs.existsSync(path)) {
+    throw new Error(`${path} already exists`);
+  }
+  fs.writeFileSync(
+    path,
+    yaml.dump(game, {
+      quotingType: '"',
+      forceQuotes: true,
+    })
+  );
 }
-fs.writeFileSync(
-  path,
-  yaml.dump(game, {
-    quotingType: '"',
-    forceQuotes: true,
-  })
-);
+
+// TODO: Add await if/when top level await is supported without
+//       "type": "module" inclusion in package.json or after removal of
+//       r2modmanPlus submodule from the repo.
+runAddCommand();

--- a/games/src/scripts/build.ts
+++ b/games/src/scripts/build.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import { buildSchemaJson } from "../schema/builder";
+import { buildSchemaJson } from "../schema/builder.js";
 
 function runBuildCommand() {
   const outdir = "./dist";

--- a/games/src/scripts/deploy.ts
+++ b/games/src/scripts/deploy.ts
@@ -1,28 +1,35 @@
 import fs from "fs";
-import { getDeployApiKey, getDeployApiUrl } from "../config";
-import { assertForStatus } from "../utils/requests";
+import { getDeployApiKey, getDeployApiUrl } from "../config.js";
+import { assertForStatus } from "../utils/requests.js";
 
-const outdir = "./dist";
-if (!fs.existsSync(outdir)) {
-  fs.mkdirSync(outdir);
+async function runDeployCommand() {
+  const outdir = "./dist";
+  if (!fs.existsSync(outdir)) {
+    fs.mkdirSync(outdir);
+  }
+  const filepath = `${outdir}/latest.json`;
+
+  if (!fs.existsSync(filepath)) {
+    throw new Error(`Unable to deploy: no file found at ${filepath}`);
+  }
+
+  const apiUrl = getDeployApiUrl();
+
+  const response = await fetch(apiUrl, {
+    method: "POST",
+    body: fs.readFileSync(filepath),
+    headers: {
+      Authorization: getDeployApiKey(),
+    },
+  });
+
+  await assertForStatus(response);
+
+  console.log("Successfully deployed!");
+  console.log(await response.text());
 }
-const filepath = `${outdir}/latest.json`;
 
-if (!fs.existsSync(filepath)) {
-  throw new Error(`Unable to deploy: no file found at ${filepath}`);
-}
-
-const apiUrl = getDeployApiUrl();
-
-const response = await fetch(apiUrl, {
-  method: "POST",
-  body: fs.readFileSync(filepath),
-  headers: {
-    Authorization: getDeployApiKey(),
-  },
-});
-
-await assertForStatus(response);
-
-console.log("Successfully deployed!");
-console.log(await response.text());
+// TODO: Add await if/when top level await is supported without
+//       "type": "module" inclusion in package.json or after removal of
+//       r2modmanPlus submodule from the repo.
+runDeployCommand();

--- a/games/src/scripts/diff.ts
+++ b/games/src/scripts/diff.ts
@@ -1,11 +1,11 @@
-import { buildSchemaJson } from "../schema/builder";
-import { getLatestSchemaUrl } from "../config";
-import { assertForStatus } from "../utils/requests";
+import { buildSchemaJson } from "../schema/builder.js";
+import { getLatestSchemaUrl } from "../config.js";
+import { assertForStatus } from "../utils/requests.js";
 import {
   CommunitySchemaType,
   SchemaType,
   validateSchemaJson,
-} from "../schema/validator";
+} from "../schema/validator.js";
 import Differ, { DiffResult } from "json-diff-kit/differ";
 
 const schemaUrl = getLatestSchemaUrl();
@@ -98,4 +98,7 @@ async function runDiffCommand() {
   }
 }
 
-await runDiffCommand();
+// TODO: Add await if/when top level await is supported without
+//       "type": "module" inclusion in package.json or after removal of
+//       r2modmanPlus submodule from the repo.
+runDiffCommand();

--- a/games/src/scripts/extract-r2modman.ts
+++ b/games/src/scripts/extract-r2modman.ts
@@ -1,27 +1,30 @@
-import GameManager from "../../r2modmanPlus/src/model/game/GameManager";
+import GameManager from "../../r2modmanPlus/src/model/game/GameManager.js";
 import { v4 as uuid } from "uuid";
 import * as yaml from "js-yaml";
 import * as fs from "fs";
-import { GameDefinition } from "../models";
+import { GameDefinition, GameModmanDefinition } from "../models.js";
 import {
   convertDisplayMode,
   convertGameType,
   convertInstallRule,
   convertModLoaderPackageMapping,
   convertPlatform,
-} from "../utils";
-import { loadGameDefinitions } from "../load";
+} from "../utils.js";
+import { loadGameDefinitions } from "../load.js";
 import {
   GAME_NAME,
   MOD_LOADER_VARIANTS,
-} from "../../r2modmanPlus/src/r2mm/installing/profile_installers/ModLoaderVariantRecord";
-import InstallationRuleApplicator from "../../r2modmanPlus/src/r2mm/installing/default_installation_rules/InstallationRuleApplicator";
-import InstallationRules from "../../r2modmanPlus/src/r2mm/installing/InstallationRules";
+} from "../../r2modmanPlus/src/r2mm/installing/profile_installers/ModLoaderVariantRecord.js";
+import InstallationRuleApplicator from "../../r2modmanPlus/src/r2mm/installing/default_installation_rules/InstallationRuleApplicator.js";
+import InstallationRules from "../../r2modmanPlus/src/r2mm/installing/InstallationRules.js";
+import Game from "../../r2modmanPlus/src/model/game/Game.js";
 
 const { generated } = loadGameDefinitions();
 const settingsIdentifierToUuid = new Map<string, string>();
 for (const def of generated) {
-  settingsIdentifierToUuid.set(def.r2modman.settingsIdentifier, def.uuid);
+  if (def.r2modman) {
+    settingsIdentifierToUuid.set(def.r2modman.settingsIdentifier, def.uuid);
+  }
 }
 
 const oldPackegeListRe = new RegExp(
@@ -41,8 +44,8 @@ InstallationRuleApplicator.apply();
 const extractRules = (
   game: GAME_NAME
 ): {
-  installRules: GameDefinition["r2modman"]["installRules"];
-  relativeFileExclusions: GameDefinition["r2modman"]["relativeFileExclusions"];
+  installRules: GameModmanDefinition["installRules"];
+  relativeFileExclusions: GameModmanDefinition["relativeFileExclusions"];
 } => {
   const rules = InstallationRules.RULES.find((x) => x.gameName == game);
   return {
@@ -51,7 +54,7 @@ const extractRules = (
   };
 };
 
-const games: GameDefinition[] = GameManager.gameList.map((x) => ({
+const games: GameDefinition[] = GameManager.gameList.map((x: Game) => ({
   uuid: settingsIdentifierToUuid.get(x.settingsIdentifier) ?? uuid(),
   label: extractThunderstoreCommunity(x.thunderstoreUrl),
   meta: {
@@ -67,14 +70,14 @@ const games: GameDefinition[] = GameManager.gameList.map((x) => ({
     dataFolderName: x.dataFolderName,
     settingsIdentifier: x.settingsIdentifier,
     packageIndex: x.thunderstoreUrl,
-    exclusionsUrl: x.exclusionsUrl,
+    // exclusionsUrl: x.exclusionsUrl,
     steamFolderName: x.steamFolderName,
     exeNames: x.exeName,
     gameInstancetype: convertGameType(x.instanceType),
     gameSelectionDisplayMode: convertDisplayMode(x.displayMode),
-    modLoaderPackages: MOD_LOADER_VARIANTS[x.internalFolderName].map(
-      convertModLoaderPackageMapping
-    ),
+    // modLoaderPackages: MOD_LOADER_VARIANTS[x.internalFolderName].map(
+    //   convertModLoaderPackageMapping
+    // ),
     ...extractRules(x.internalFolderName),
   },
 }));

--- a/games/src/scripts/validate.ts
+++ b/games/src/scripts/validate.ts
@@ -1,9 +1,12 @@
-import { buildSchemaJson } from "../schema/builder";
-import { validateSchemaJson } from "../schema/validator";
+import { buildSchemaJson } from "../schema/builder.js";
+import { validateSchemaJson } from "../schema/validator.js";
 
 async function runValidateCommand() {
   validateSchemaJson(buildSchemaJson());
   console.log("Schema validated successfully!");
 }
 
-await runValidateCommand();
+// TODO: Add await if/when top level await is supported without
+//       "type": "module" inclusion in package.json or after removal of
+//       r2modmanPlus submodule from the repo.
+runValidateCommand();

--- a/games/src/utils.ts
+++ b/games/src/utils.ts
@@ -1,4 +1,4 @@
-import { GameInstanceType } from "../r2modmanPlus/src/model/game/GameInstanceType";
+import { GameInstanceType } from "../r2modmanPlus/src/model/game/GameInstanceType.js";
 import {
   DisplayType,
   DistributionPlatform,
@@ -7,12 +7,12 @@ import {
   ModmanModLoaderPackage,
   ModmanPackageLoader,
   ModmanTrackingMethod,
-} from "./models";
-import { StorePlatform } from "../r2modmanPlus/src/model/game/StorePlatform";
-import { GameSelectionDisplayMode } from "../r2modmanPlus/src/model/game/GameSelectionDisplayMode";
-import { PackageLoader } from "../r2modmanPlus/src/model/installing/PackageLoader";
-import { RuleSubtype } from "../r2modmanPlus/src/r2mm/installing/InstallationRules";
-import ModLoaderPackageMapping from "../r2modmanPlus/src/model/installing/ModLoaderPackageMapping";
+} from "./models.js";
+import { StorePlatform } from "../r2modmanPlus/src/model/game/StorePlatform.js";
+import { GameSelectionDisplayMode } from "../r2modmanPlus/src/model/game/GameSelectionDisplayMode.js";
+import { PackageLoader } from "../r2modmanPlus/src/model/installing/PackageLoader.js";
+import { RuleSubtype } from "../r2modmanPlus/src/r2mm/installing/InstallationRules.js";
+import ModLoaderPackageMapping from "../r2modmanPlus/src/model/installing/ModLoaderPackageMapping.js";
 
 export function convertPlatform(platform: StorePlatform): DistributionPlatform {
   switch (platform) {
@@ -93,6 +93,8 @@ export function convertTrackingMethod(
       return "state";
     case "SUBDIR_NO_FLATTEN":
       return "subdir-no-flatten";
+    case "PACKAGE_ZIP":
+      return "package-zip";
   }
 }
 
@@ -106,5 +108,19 @@ export function convertPackageLoader(
       return "melonloader";
     case PackageLoader.NORTHSTAR:
       return "northstar";
+    case PackageLoader.GODOT_ML:
+      return "godot";
+    case PackageLoader.ANCIENT_DUNGEON_VR:
+      return "ancient-dungeon-vr";
+    case PackageLoader.SHIMLOADER:
+      return "shimloader";
+    case PackageLoader.LOVELY:
+      return "lovely";
+    case PackageLoader.RETURN_OF_MODDING:
+      return "return-of-modding";
+    case PackageLoader.GDWEAVE:
+      return "gdweave";
+    case PackageLoader.RECURSIVE_MELON_LOADER:
+      return "melonloader-recursive";
   }
 }

--- a/games/tsconfig.json
+++ b/games/tsconfig.json
@@ -1,16 +1,14 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "module": "es2022",
+    "module": "NodeNext",
     "esModuleInterop": true,
-    "moduleResolution": "nodenext",
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "NodeNext",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
     "types": ["node"]
   },
-  "ts-node": {
-    "esm": true,
-    "experimentalSpecifierResolution": "node"
-  }
+  "exclude": ["r2modmanPlus"]
 }

--- a/games/yarn.lock
+++ b/games/yarn.lock
@@ -14,120 +14,130 @@
     omggif "^1.0.10"
     pngjs "^6.0.0"
 
-"@esbuild/aix-ppc64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz#d1bc06aedb6936b3b6d313bf809a5a40387d2b7f"
-  integrity sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==
+"@esbuild/aix-ppc64@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz#b87036f644f572efb2b3c75746c97d1d2d87ace8"
+  integrity sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==
 
-"@esbuild/android-arm64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz#7ad65a36cfdb7e0d429c353e00f680d737c2aed4"
-  integrity sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==
+"@esbuild/android-arm64@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.2.tgz#5ca7dc20a18f18960ad8d5e6ef5cf7b0a256e196"
+  integrity sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==
 
-"@esbuild/android-arm@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.19.12.tgz#b0c26536f37776162ca8bde25e42040c203f2824"
-  integrity sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==
+"@esbuild/android-arm@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.2.tgz#3c49f607b7082cde70c6ce0c011c362c57a194ee"
+  integrity sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==
 
-"@esbuild/android-x64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.19.12.tgz#cb13e2211282012194d89bf3bfe7721273473b3d"
-  integrity sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==
+"@esbuild/android-x64@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.2.tgz#8a00147780016aff59e04f1036e7cb1b683859e2"
+  integrity sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==
 
-"@esbuild/darwin-arm64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz#cbee41e988020d4b516e9d9e44dd29200996275e"
-  integrity sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==
+"@esbuild/darwin-arm64@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.2.tgz#486efe7599a8d90a27780f2bb0318d9a85c6c423"
+  integrity sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==
 
-"@esbuild/darwin-x64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz#e37d9633246d52aecf491ee916ece709f9d5f4cd"
-  integrity sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==
+"@esbuild/darwin-x64@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.2.tgz#95ee222aacf668c7a4f3d7ee87b3240a51baf374"
+  integrity sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==
 
-"@esbuild/freebsd-arm64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz#1ee4d8b682ed363b08af74d1ea2b2b4dbba76487"
-  integrity sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==
+"@esbuild/freebsd-arm64@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.2.tgz#67efceda8554b6fc6a43476feba068fb37fa2ef6"
+  integrity sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==
 
-"@esbuild/freebsd-x64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz#37a693553d42ff77cd7126764b535fb6cc28a11c"
-  integrity sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==
+"@esbuild/freebsd-x64@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.2.tgz#88a9d7ecdd3adadbfe5227c2122d24816959b809"
+  integrity sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==
 
-"@esbuild/linux-arm64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz#be9b145985ec6c57470e0e051d887b09dddb2d4b"
-  integrity sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==
+"@esbuild/linux-arm64@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.2.tgz#87be1099b2bbe61282333b084737d46bc8308058"
+  integrity sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==
 
-"@esbuild/linux-arm@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz#207ecd982a8db95f7b5279207d0ff2331acf5eef"
-  integrity sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==
+"@esbuild/linux-arm@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.2.tgz#72a285b0fe64496e191fcad222185d7bf9f816f6"
+  integrity sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==
 
-"@esbuild/linux-ia32@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz#d0d86b5ca1562523dc284a6723293a52d5860601"
-  integrity sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==
+"@esbuild/linux-ia32@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.2.tgz#337a87a4c4dd48a832baed5cbb022be20809d737"
+  integrity sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==
 
-"@esbuild/linux-loong64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz#9a37f87fec4b8408e682b528391fa22afd952299"
-  integrity sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==
+"@esbuild/linux-loong64@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.2.tgz#1b81aa77103d6b8a8cfa7c094ed3d25c7579ba2a"
+  integrity sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==
 
-"@esbuild/linux-mips64el@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz#4ddebd4e6eeba20b509d8e74c8e30d8ace0b89ec"
-  integrity sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==
+"@esbuild/linux-mips64el@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.2.tgz#afbe380b6992e7459bf7c2c3b9556633b2e47f30"
+  integrity sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==
 
-"@esbuild/linux-ppc64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz#adb67dadb73656849f63cd522f5ecb351dd8dee8"
-  integrity sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==
+"@esbuild/linux-ppc64@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.2.tgz#6bf8695cab8a2b135cca1aa555226dc932d52067"
+  integrity sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==
 
-"@esbuild/linux-riscv64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz#11bc0698bf0a2abf8727f1c7ace2112612c15adf"
-  integrity sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==
+"@esbuild/linux-riscv64@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.2.tgz#43c2d67a1a39199fb06ba978aebb44992d7becc3"
+  integrity sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==
 
-"@esbuild/linux-s390x@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz#e86fb8ffba7c5c92ba91fc3b27ed5a70196c3cc8"
-  integrity sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==
+"@esbuild/linux-s390x@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.2.tgz#419e25737ec815c6dce2cd20d026e347cbb7a602"
+  integrity sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==
 
-"@esbuild/linux-x64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz#5f37cfdc705aea687dfe5dfbec086a05acfe9c78"
-  integrity sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==
+"@esbuild/linux-x64@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.2.tgz#22451f6edbba84abe754a8cbd8528ff6e28d9bcb"
+  integrity sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==
 
-"@esbuild/netbsd-x64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz#29da566a75324e0d0dd7e47519ba2f7ef168657b"
-  integrity sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==
+"@esbuild/netbsd-arm64@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.2.tgz#744affd3b8d8236b08c5210d828b0698a62c58ac"
+  integrity sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==
 
-"@esbuild/openbsd-x64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz#306c0acbdb5a99c95be98bdd1d47c916e7dc3ff0"
-  integrity sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==
+"@esbuild/netbsd-x64@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.2.tgz#dbbe7521fd6d7352f34328d676af923fc0f8a78f"
+  integrity sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==
 
-"@esbuild/sunos-x64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz#0933eaab9af8b9b2c930236f62aae3fc593faf30"
-  integrity sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==
+"@esbuild/openbsd-arm64@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.2.tgz#f9caf987e3e0570500832b487ce3039ca648ce9f"
+  integrity sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==
 
-"@esbuild/win32-arm64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz#773bdbaa1971b36db2f6560088639ccd1e6773ae"
-  integrity sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==
+"@esbuild/openbsd-x64@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.2.tgz#d2bb6a0f8ffea7b394bb43dfccbb07cabd89f768"
+  integrity sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==
 
-"@esbuild/win32-ia32@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz#000516cad06354cc84a73f0943a4aa690ef6fd67"
-  integrity sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==
+"@esbuild/sunos-x64@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.2.tgz#49b437ed63fe333b92137b7a0c65a65852031afb"
+  integrity sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==
 
-"@esbuild/win32-x64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz#c57c8afbb4054a3ab8317591a0b7320360b444ae"
-  integrity sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==
+"@esbuild/win32-arm64@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.2.tgz#081424168463c7d6c7fb78f631aede0c104373cf"
+  integrity sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==
+
+"@esbuild/win32-ia32@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.2.tgz#3f9e87143ddd003133d21384944a6c6cadf9693f"
+  integrity sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==
+
+"@esbuild/win32-x64@0.25.2":
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.2.tgz#839f72c2decd378f86b8f525e1979a97b920c67d"
+  integrity sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==
 
 "@inquirer/checkbox@^1.3.6":
   version "1.3.6"
@@ -370,34 +380,36 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-esbuild@~0.19.10:
-  version "0.19.12"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.19.12.tgz#dc82ee5dc79e82f5a5c3b4323a2a641827db3e04"
-  integrity sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==
+esbuild@~0.25.0:
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.25.2.tgz#55a1d9ebcb3aa2f95e8bba9e900c1a5061bc168b"
+  integrity sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==
   optionalDependencies:
-    "@esbuild/aix-ppc64" "0.19.12"
-    "@esbuild/android-arm" "0.19.12"
-    "@esbuild/android-arm64" "0.19.12"
-    "@esbuild/android-x64" "0.19.12"
-    "@esbuild/darwin-arm64" "0.19.12"
-    "@esbuild/darwin-x64" "0.19.12"
-    "@esbuild/freebsd-arm64" "0.19.12"
-    "@esbuild/freebsd-x64" "0.19.12"
-    "@esbuild/linux-arm" "0.19.12"
-    "@esbuild/linux-arm64" "0.19.12"
-    "@esbuild/linux-ia32" "0.19.12"
-    "@esbuild/linux-loong64" "0.19.12"
-    "@esbuild/linux-mips64el" "0.19.12"
-    "@esbuild/linux-ppc64" "0.19.12"
-    "@esbuild/linux-riscv64" "0.19.12"
-    "@esbuild/linux-s390x" "0.19.12"
-    "@esbuild/linux-x64" "0.19.12"
-    "@esbuild/netbsd-x64" "0.19.12"
-    "@esbuild/openbsd-x64" "0.19.12"
-    "@esbuild/sunos-x64" "0.19.12"
-    "@esbuild/win32-arm64" "0.19.12"
-    "@esbuild/win32-ia32" "0.19.12"
-    "@esbuild/win32-x64" "0.19.12"
+    "@esbuild/aix-ppc64" "0.25.2"
+    "@esbuild/android-arm" "0.25.2"
+    "@esbuild/android-arm64" "0.25.2"
+    "@esbuild/android-x64" "0.25.2"
+    "@esbuild/darwin-arm64" "0.25.2"
+    "@esbuild/darwin-x64" "0.25.2"
+    "@esbuild/freebsd-arm64" "0.25.2"
+    "@esbuild/freebsd-x64" "0.25.2"
+    "@esbuild/linux-arm" "0.25.2"
+    "@esbuild/linux-arm64" "0.25.2"
+    "@esbuild/linux-ia32" "0.25.2"
+    "@esbuild/linux-loong64" "0.25.2"
+    "@esbuild/linux-mips64el" "0.25.2"
+    "@esbuild/linux-ppc64" "0.25.2"
+    "@esbuild/linux-riscv64" "0.25.2"
+    "@esbuild/linux-s390x" "0.25.2"
+    "@esbuild/linux-x64" "0.25.2"
+    "@esbuild/netbsd-arm64" "0.25.2"
+    "@esbuild/netbsd-x64" "0.25.2"
+    "@esbuild/openbsd-arm64" "0.25.2"
+    "@esbuild/openbsd-x64" "0.25.2"
+    "@esbuild/sunos-x64" "0.25.2"
+    "@esbuild/win32-arm64" "0.25.2"
+    "@esbuild/win32-ia32" "0.25.2"
+    "@esbuild/win32-x64" "0.25.2"
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -430,10 +442,10 @@ fsevents@~2.3.3:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
-get-tsconfig@^4.7.2:
-  version "4.7.3"
-  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.7.3.tgz#0498163d98f7b58484dd4906999c0c9d5f103f83"
-  integrity sha512-ZvkrzoUA0PQZM6fy6+/Hce561s+faD1rsNwhnO5FelNjyy7EMGJ3Rz1AQ8GYDWjhRs/7dBLOEJvhK8MiEJOAFg==
+get-tsconfig@^4.7.5:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.10.0.tgz#403a682b373a823612475a4c2928c7326fc0f6bb"
+  integrity sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
@@ -643,13 +655,13 @@ tree-kit@^0.8.7:
   resolved "https://registry.yarnpkg.com/tree-kit/-/tree-kit-0.8.8.tgz#695c83b72926b0d04a178648fb128d31be2d059e"
   integrity sha512-L7zwpXp0/Nha6mljVcVOnhhxuCkFRWmt26wza3TKnyMBewid4F2vyiVdcSsw41ZoG1Wj+3lM48Er9lhttbxfLA==
 
-tsx@^4.7.2:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.7.2.tgz#a108b1a6e16876cd4c9a4b4ba263f2a07f9cf562"
-  integrity sha512-BCNd4kz6fz12fyrgCTEdZHGJ9fWTGeUzXmQysh0RVocDY3h4frk05ZNCXSy4kIenF7y/QnrdiVpTsyNRn6vlAw==
+tsx@4.19.3:
+  version "4.19.3"
+  resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.19.3.tgz#2bdbcb87089374d933596f8645615142ed727666"
+  integrity sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==
   dependencies:
-    esbuild "~0.19.10"
-    get-tsconfig "^4.7.2"
+    esbuild "~0.25.0"
+    get-tsconfig "^4.7.5"
   optionalDependencies:
     fsevents "~2.3.3"
 
@@ -658,10 +670,10 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-typescript@^4.8.3:
-  version "4.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.3.tgz#d59344522c4bc464a65a730ac695007fdb66dd88"
-  integrity sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==
+typescript@5.5:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
+  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
 
 uniq@^1.0.0:
   version "1.0.1"
@@ -682,7 +694,7 @@ wrap-ansi@^6.0.1:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
-zod@^3.23.4:
-  version "3.23.4"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.4.tgz#c63805b2f39e10d4ab3d55eb3c8cdb472c79dfb1"
-  integrity sha512-/AtWOKbBgjzEYYQRNfoGKHObgfAZag6qUJX1VbHo2PRBgS+wfWagEY2mizjfyAPcGesrJOcx/wcl0L9WnVrHFw==
+zod@3.24.2:
+  version "3.24.2"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.24.2.tgz#8efa74126287c675e92f46871cfc8d15c34372b3"
+  integrity sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==


### PR DESCRIPTION
Update TypeScript & related configs and code so TSC can actually be run against the codebase without errors.

The main tradeoff that had to be made was to stop using top level await statements in scripts, as using `"type": "module"` in package.json caused the r2modmanPlus imports to not function properly.

In the future once the r2modmanPlus submodule is removed, the aforementioned change can be reverted.