### PR TITLE
Add multiple deployment targets & config defaults

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,5 +28,4 @@ jobs:
         run: "yarn run diff && yarn run deploy"
         env:
           DEPLOY_API_URL: ${{ vars.DEPLOY_API_URL }}
-          LATEST_SCHEMA_URL: ${{ vars.LATEST_SCHEMA_URL }}
           DEPLOY_API_KEY: ${{ secrets.DEPLOY_API_KEY }}

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -18,5 +18,3 @@ jobs:
         run: "yarn install --frozen-lockfile"
       - name: "Validate & Diff"
         run: "yarn run validate && yarn run diff"
-        env:
-          LATEST_SCHEMA_URL: ${{ vars.LATEST_SCHEMA_URL }}

--- a/games/src/config.ts
+++ b/games/src/config.ts
@@ -7,17 +7,39 @@ const requireConfig = (name: string, value: string | undefined): string => {
   return value;
 };
 
-const DEPLOY_API_URL: string | undefined = process.env.DEPLOY_API_URL;
+const getConfigOrDefault = (name: string, defaultValue: string): string => {
+  return process.env[name] ?? defaultValue;
+};
 
+/* For JSON schema */
+export const getDeployUrlForSchema = () =>
+  getConfigOrDefault(
+    "DEPLOY_URL_FOR_SCHEMA",
+    "https://thunderstore.io/api/experimental/schema/ecosystem-json-schema/"
+  );
+
+/* For data */
+export const getDeployUrlForData = () =>
+  getConfigOrDefault(
+    "DEPLOY_URL_FOR_DATA",
+    "https://thunderstore.io/api/experimental/schema/ecosystem-json-data/"
+  );
+
+/* Legacy */
 export const getDeployApiUrl = () =>
-  requireConfig("DEPLOY_API_URL", DEPLOY_API_URL);
+  getConfigOrDefault(
+    "DEPLOY_API_URL",
+    "https://thunderstore.io/api/experimental/schema/dev/"
+  );
+
+/* This is what diff compares against */
+export const getLatestSchemaUrl = () =>
+  getConfigOrDefault(
+    "LATEST_SCHEMA_URL",
+    "https://thunderstore.io/api/experimental/schema/dev/latest/"
+  );
 
 const DEPLOY_API_KEY: string | undefined = process.env.DEPLOY_API_KEY;
 
 export const getDeployApiKey = () =>
   requireConfig("DEPLOY_API_KEY", DEPLOY_API_KEY);
-
-const LATEST_SCHEMA_URL: string | undefined = process.env.LATEST_SCHEMA_URL;
-
-export const getLatestSchemaUrl = () =>
-  requireConfig("LATEST_SCHEMA_URL", LATEST_SCHEMA_URL);


### PR DESCRIPTION
- Add deployment target for the JSON schema output
- Add a new better named deployment target for the JSON data
- Keep the old deployment target around for backwards compat
- Remove environment variable requirement from validation scripts

Notably these changes should enable 3rd party PRs to succeed in running CI pipelines. These were previously failing due to GitHub not allowing fork-sourced PRs from reading origin CI configs (even if they weren't marked as secrets).