### PR TITLE
Mark "defaultFileExtensions" required

### DIFF
--- a/games/src/schema/validator.ts
+++ b/games/src/schema/validator.ts
@@ -37,7 +37,7 @@ export type CommunitySchemaType = z.infer<typeof communitySchema>;
 const _baseInstallRuleSchema = z.strictObject({
   route: z.string(),
   trackingMethod: z.enum(ModmanTrackingMethodValues),
-  defaultFileExtensions: z.array(z.string()).optional(),
+  defaultFileExtensions: z.array(z.string()),
   isDefaultLocation: z.boolean(),
 });
 type _installRuleSchema = z.infer<typeof _baseInstallRuleSchema> & {


### PR DESCRIPTION
Mark the `defaultFileExtensions` field required to stay in line with r2modman's current code, as the field was already populated in data either way.