### PR TITLE
Update deployment script to upload sequentially

### DIFF
--- a/games/src/scripts/deploy.ts
+++ b/games/src/scripts/deploy.ts
@@ -46,9 +46,16 @@ async function runDeployCommand() {
       filepath: schemaPath,
       url: getDeployUrlForSchema(),
     },
-  ].map(doUpload);
+  ];
 
-  await Promise.all(uploads);
+  for (const target of uploads) {
+    await doUpload(target);
+  }
+
+  // TODO: Swap to parallel uploads once serverside race condition fixed
+  // const promises = uploads.map(doUpload);
+  // await await Promise.all(promises);
+
   console.log("Deployed successfully!");
 }
 


### PR DESCRIPTION
There's a serverside race condition bug with the deployment endpoint, where if two identical files are uploaded in parallel, one of the uploads will fail (even if release channels are different).

As a temporary workaround convert the deployment process to uploading files sequentially. Parallel uploads can be re-enabled once the serverside bug has been addressed, but as it requires distributed locking, it's likely going to take longer than a workaround on the client now.