### PR TITLE
Support multiple r2modman definitions per game

### DIFF
--- a/games/data/generated/20-minutes-till-dawn.yml
+++ b/games/data/generated/20-minutes-till-dawn.yml
@@ -9,45 +9,53 @@ distributions:
   - platform: "epic-games-store"
     identifier: "4656facc740742a39e265b026e13d075"
 r2modman:
-  internalFolderName: "20MinutesTillDawn"
-  dataFolderName: "MinutesTillDawn_Data"
-  settingsIdentifier: "20MinutesTillDawn"
-  packageIndex: "https://thunderstore.io/c/20-minutes-till-dawn/api/v1/package-listing-index/"
-  steamFolderName: "20MinuteTillDawn"
-  exeNames:
-    - "MinutesTillDawn.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "mtd"
-    - "20mtd"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "20 Minutes Till Dawn"
+      iconUrl: "20MinutesTillDawn.jpg"
+    internalFolderName: "20MinutesTillDawn"
+    dataFolderName: "MinutesTillDawn_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1966900"
+      - platform: "epic-games-store"
+        identifier: "4656facc740742a39e265b026e13d075"
+    settingsIdentifier: "20MinutesTillDawn"
+    packageIndex: "https://thunderstore.io/c/20-minutes-till-dawn/api/v1/package-listing-index/"
+    steamFolderName: "20MinuteTillDawn"
+    exeNames:
+      - "MinutesTillDawn.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "mtd"
+      - "20mtd"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/across-the-obelisk.yml
+++ b/games/data/generated/across-the-obelisk.yml
@@ -7,45 +7,51 @@ distributions:
   - platform: "steam"
     identifier: "1385380"
 r2modman:
-  internalFolderName: "AcrossTheObelisk"
-  dataFolderName: "AcrossTheObelisk_Data"
-  settingsIdentifier: "AcrossTheObelisk"
-  packageIndex: "https://thunderstore.io/c/across-the-obelisk/api/v1/package-listing-index/"
-  steamFolderName: "Across the Obelisk"
-  exeNames:
-    - "AcrossTheObelisk.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "ato"
-    - "ao"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Across the Obelisk"
+      iconUrl: "AcrossTheObelisk.png"
+    internalFolderName: "AcrossTheObelisk"
+    dataFolderName: "AcrossTheObelisk_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1385380"
+    settingsIdentifier: "AcrossTheObelisk"
+    packageIndex: "https://thunderstore.io/c/across-the-obelisk/api/v1/package-listing-index/"
+    steamFolderName: "Across the Obelisk"
+    exeNames:
+      - "AcrossTheObelisk.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "ato"
+      - "ao"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/against-the-storm.yml
+++ b/games/data/generated/against-the-storm.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1336490"
 r2modman:
-  internalFolderName: "AgainstTheStorm"
-  dataFolderName: "Against the Storm_Data"
-  settingsIdentifier: "AgainstTheStorm"
-  packageIndex: "https://thunderstore.io/c/against-the-storm/api/v1/package-listing-index/"
-  steamFolderName: "Against the Storm"
-  exeNames:
-    - "Against the Storm.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "ats"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Against the Storm"
+      iconUrl: "AgainstTheStorm.png"
+    internalFolderName: "AgainstTheStorm"
+    dataFolderName: "Against the Storm_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1336490"
+    settingsIdentifier: "AgainstTheStorm"
+    packageIndex: "https://thunderstore.io/c/against-the-storm/api/v1/package-listing-index/"
+    steamFolderName: "Against the Storm"
+    exeNames:
+      - "Against the Storm.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "ats"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/against.yml
+++ b/games/data/generated/against.yml
@@ -7,43 +7,49 @@ distributions:
   - platform: "steam"
     identifier: "1584840"
 r2modman:
-  internalFolderName: "AGAINST"
-  dataFolderName: "AGAINST_Data"
-  settingsIdentifier: "AGAINST"
-  packageIndex: "https://thunderstore.io/c/against/api/v1/package-listing-index/"
-  steamFolderName: "AGAINST_steam"
-  exeNames:
-    - "AGAINST.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "AGAINST"
+      iconUrl: "AGAINST.jpg"
+    internalFolderName: "AGAINST"
+    dataFolderName: "AGAINST_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1584840"
+    settingsIdentifier: "AGAINST"
+    packageIndex: "https://thunderstore.io/c/against/api/v1/package-listing-index/"
+    steamFolderName: "AGAINST_steam"
+    exeNames:
+      - "AGAINST.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/ale-and-tale-tavern.yml
+++ b/games/data/generated/ale-and-tale-tavern.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2683150"
 r2modman:
-  internalFolderName: "AleAndTaleTavern"
-  dataFolderName: "Ale and Tale Tavern_Data"
-  settingsIdentifier: "AleAndTaleTavern"
-  packageIndex: "https://thunderstore.io/c/ale-and-tale-tavern/api/v1/package-listing-index/"
-  steamFolderName: "Ale & Tale Tavern"
-  exeNames:
-    - "Ale and Tale Tavern.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Ale & Tale Tavern"
+      iconUrl: "AleAndTaleTavern.png"
+    internalFolderName: "AleAndTaleTavern"
+    dataFolderName: "Ale and Tale Tavern_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2683150"
+    settingsIdentifier: "AleAndTaleTavern"
+    packageIndex: "https://thunderstore.io/c/ale-and-tale-tavern/api/v1/package-listing-index/"
+    steamFolderName: "Ale & Tale Tavern"
+    exeNames:
+      - "Ale and Tale Tavern.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/aloft.yml
+++ b/games/data/generated/aloft.yml
@@ -7,43 +7,49 @@ distributions:
   - platform: "steam"
     identifier: "1660080"
 r2modman:
-  internalFolderName: "Aloft"
-  dataFolderName: "Aloft_Data"
-  settingsIdentifier: "Aloft"
-  packageIndex: "https://thunderstore.io/c/aloft/api/v1/package-listing-index/"
-  steamFolderName: "Aloft Demo"
-  exeNames:
-    - "Aloft.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Aloft"
+      iconUrl: "Aloft.png"
+    internalFolderName: "Aloft"
+    dataFolderName: "Aloft_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1660080"
+    settingsIdentifier: "Aloft"
+    packageIndex: "https://thunderstore.io/c/aloft/api/v1/package-listing-index/"
+    steamFolderName: "Aloft Demo"
+    exeNames:
+      - "Aloft.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/among-us.yml
+++ b/games/data/generated/among-us.yml
@@ -13,44 +13,56 @@ distributions:
   - platform: "other"
     identifier: null
 r2modman:
-  internalFolderName: "AmongUs"
-  dataFolderName: "Among Us_Data"
-  settingsIdentifier: "AmongUs"
-  packageIndex: "https://thunderstore.io/c/among-us/api/v1/package-listing-index/"
-  steamFolderName: "Among Us"
-  exeNames:
-    - "Among Us.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "au"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Among Us"
+      iconUrl: "AmongUs.png"
+    internalFolderName: "AmongUs"
+    dataFolderName: "Among Us_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "945360"
+      - platform: "epic-games-store"
+        identifier: "among-us"
+      - platform: "xbox-game-pass"
+        identifier: "Innersloth.AmongUs"
+      - platform: "other"
+        identifier: null
+    settingsIdentifier: "AmongUs"
+    packageIndex: "https://thunderstore.io/c/among-us/api/v1/package-listing-index/"
+    steamFolderName: "Among Us"
+    exeNames:
+      - "Among Us.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "au"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/ancient-dungeon-vr.yml
+++ b/games/data/generated/ancient-dungeon-vr.yml
@@ -9,22 +9,30 @@ distributions:
   - platform: "oculus-store"
     identifier: null
 r2modman:
-  internalFolderName: "AncientDungeonVR"
-  dataFolderName: "Ancient_Dungeon_Data"
-  settingsIdentifier: "AncientDungeonVR"
-  packageIndex: "https://thunderstore.io/c/ancient-dungeon-vr/api/v1/package-listing-index/"
-  steamFolderName: "Ancient Dungeon VR"
-  exeNames:
-    - "Ancient_Dungeon.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "adv"
-  packageLoader: null
-  installRules:
-    - route: "mods"
-      defaultFileExtensions: []
-      trackingMethod: "subdir-no-flatten"
-      subRoutes: []
-      isDefaultLocation: true
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Ancient Dungeon VR"
+      iconUrl: "ancient-dungeon-vr.png"
+    internalFolderName: "AncientDungeonVR"
+    dataFolderName: "Ancient_Dungeon_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1125240"
+      - platform: "oculus-store"
+        identifier: null
+    settingsIdentifier: "AncientDungeonVR"
+    packageIndex: "https://thunderstore.io/c/ancient-dungeon-vr/api/v1/package-listing-index/"
+    steamFolderName: "Ancient Dungeon VR"
+    exeNames:
+      - "Ancient_Dungeon.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "adv"
+    packageLoader: null
+    installRules:
+      - route: "mods"
+        defaultFileExtensions: []
+        trackingMethod: "subdir-no-flatten"
+        subRoutes: []
+        isDefaultLocation: true
+    relativeFileExclusions: null

--- a/games/data/generated/aneurism-iv.yml
+++ b/games/data/generated/aneurism-iv.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2773280"
 r2modman:
-  internalFolderName: "ANEURISMIV"
-  dataFolderName: "ANEURISM IV_Data"
-  settingsIdentifier: "ANEURISMIV"
-  packageIndex: "https://thunderstore.io/c/aneurism-iv/api/v1/package-listing-index/"
-  steamFolderName: "ANEURISMIV"
-  exeNames:
-    - "ANEURISM IV.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "ANEURISM IV"
+      iconUrl: "ANEURISM_IV.png"
+    internalFolderName: "ANEURISMIV"
+    dataFolderName: "ANEURISM IV_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2773280"
+    settingsIdentifier: "ANEURISMIV"
+    packageIndex: "https://thunderstore.io/c/aneurism-iv/api/v1/package-listing-index/"
+    steamFolderName: "ANEURISMIV"
+    exeNames:
+      - "ANEURISM IV.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/another-crabs-treasure.yml
+++ b/games/data/generated/another-crabs-treasure.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1887840"
 r2modman:
-  internalFolderName: "AnotherCrabsTreasure"
-  dataFolderName: "AnotherCrabsTreasure_Data"
-  settingsIdentifier: "AnotherCrabsTreasure"
-  packageIndex: "https://thunderstore.io/c/another-crabs-treasure/api/v1/package-listing-index/"
-  steamFolderName: "AnotherCrabsTreasure"
-  exeNames:
-    - "AnotherCrabsTreasure.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "act"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Another Crab's Treasure"
+      iconUrl: "AnotherCrabsTreasure.png"
+    internalFolderName: "AnotherCrabsTreasure"
+    dataFolderName: "AnotherCrabsTreasure_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1887840"
+    settingsIdentifier: "AnotherCrabsTreasure"
+    packageIndex: "https://thunderstore.io/c/another-crabs-treasure/api/v1/package-listing-index/"
+    steamFolderName: "AnotherCrabsTreasure"
+    exeNames:
+      - "AnotherCrabsTreasure.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "act"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/arcus-chroma.yml
+++ b/games/data/generated/arcus-chroma.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1447350"
 r2modman:
-  internalFolderName: "ArcusChroma"
-  dataFolderName: "Arcus Chroma_Data"
-  settingsIdentifier: "ArcusChroma"
-  packageIndex: "https://thunderstore.io/c/arcus-chroma/api/v1/package-listing-index/"
-  steamFolderName: "Arcus Chroma"
-  exeNames:
-    - "Arcus Chroma.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Arcus Chroma"
+      iconUrl: "ArcusChroma.png"
+    internalFolderName: "ArcusChroma"
+    dataFolderName: "Arcus Chroma_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1447350"
+    settingsIdentifier: "ArcusChroma"
+    packageIndex: "https://thunderstore.io/c/arcus-chroma/api/v1/package-listing-index/"
+    steamFolderName: "Arcus Chroma"
+    exeNames:
+      - "Arcus Chroma.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/aska.yml
+++ b/games/data/generated/aska.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1898300"
 r2modman:
-  internalFolderName: "ASKA"
-  dataFolderName: "ASKA_Data"
-  settingsIdentifier: "ASKA"
-  packageIndex: "https://thunderstore.io/c/aska/api/v1/package-listing-index/"
-  steamFolderName: "ASKA"
-  exeNames:
-    - "Aska.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "ASKA"
+      iconUrl: "ASKA.png"
+    internalFolderName: "ASKA"
+    dataFolderName: "ASKA_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1898300"
+    settingsIdentifier: "ASKA"
+    packageIndex: "https://thunderstore.io/c/aska/api/v1/package-listing-index/"
+    steamFolderName: "ASKA"
+    exeNames:
+      - "Aska.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/atlyss.yml
+++ b/games/data/generated/atlyss.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2768430"
 r2modman:
-  internalFolderName: "ATLYSS"
-  dataFolderName: "ATLYSS_Data"
-  settingsIdentifier: "ATLYSS"
-  packageIndex: "https://thunderstore.io/c/atlyss/api/v1/package-listing-index/"
-  steamFolderName: "ATLYSS"
-  exeNames:
-    - "ATLYSS.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "ATLYSS"
+      iconUrl: "ATLYSS.png"
+    internalFolderName: "ATLYSS"
+    dataFolderName: "ATLYSS_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2768430"
+    settingsIdentifier: "ATLYSS"
+    packageIndex: "https://thunderstore.io/c/atlyss/api/v1/package-listing-index/"
+    steamFolderName: "ATLYSS"
+    exeNames:
+      - "ATLYSS.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/atomicrops.yml
+++ b/games/data/generated/atomicrops.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "757320"
 r2modman:
-  internalFolderName: "Atomicrops"
-  dataFolderName: "Atomicrops_Data"
-  settingsIdentifier: "Atomicrops"
-  packageIndex: "https://thunderstore.io/c/atomicrops/api/v1/package-listing-index/"
-  steamFolderName: "Atomicrops"
-  exeNames:
-    - "Atomicrops.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "ac"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Atomicrops"
+      iconUrl: "Atomicrops.jpg"
+    internalFolderName: "Atomicrops"
+    dataFolderName: "Atomicrops_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "757320"
+    settingsIdentifier: "Atomicrops"
+    packageIndex: "https://thunderstore.io/c/atomicrops/api/v1/package-listing-index/"
+    steamFolderName: "Atomicrops"
+    exeNames:
+      - "Atomicrops.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "ac"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/atrio-the-dark-wild.yml
+++ b/games/data/generated/atrio-the-dark-wild.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1125390"
 r2modman:
-  internalFolderName: "AtrioTheDarkWild"
-  dataFolderName: "Atrio_Data"
-  settingsIdentifier: "AtrioTheDarkWild"
-  packageIndex: "https://thunderstore.io/c/atrio-the-dark-wild/api/v1/package-listing-index/"
-  steamFolderName: "Atrio The Dark Wild"
-  exeNames:
-    - "Atrio.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "adw"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Atrio: The Dark Wild"
+      iconUrl: "atrio-the-dark-wild.jpg"
+    internalFolderName: "AtrioTheDarkWild"
+    dataFolderName: "Atrio_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1125390"
+    settingsIdentifier: "AtrioTheDarkWild"
+    packageIndex: "https://thunderstore.io/c/atrio-the-dark-wild/api/v1/package-listing-index/"
+    steamFolderName: "Atrio The Dark Wild"
+    exeNames:
+      - "Atrio.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "adw"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/back-to-the-dawn.yml
+++ b/games/data/generated/back-to-the-dawn.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1735700"
 r2modman:
-  internalFolderName: "BacktotheDawn"
-  dataFolderName: "Back To The Dawn_Data"
-  settingsIdentifier: "BacktotheDawn"
-  packageIndex: "https://thunderstore.io/c/back-to-the-dawn/api/v1/package-listing-index/"
-  steamFolderName: "MetalHeadGames"
-  exeNames:
-    - "Back To The Dawn.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "bttd"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Back to the Dawn"
+      iconUrl: "BackToTheDawn.png"
+    internalFolderName: "BacktotheDawn"
+    dataFolderName: "Back To The Dawn_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1735700"
+    settingsIdentifier: "BacktotheDawn"
+    packageIndex: "https://thunderstore.io/c/back-to-the-dawn/api/v1/package-listing-index/"
+    steamFolderName: "MetalHeadGames"
+    exeNames:
+      - "Back To The Dawn.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "bttd"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/backpack-hero.yml
+++ b/games/data/generated/backpack-hero.yml
@@ -7,56 +7,62 @@ distributions:
   - platform: "steam"
     identifier: "1970580"
 r2modman:
-  internalFolderName: "BackpackHero"
-  dataFolderName: "Backpack Hero_Data"
-  settingsIdentifier: "BackpackHero"
-  packageIndex: "https://thunderstore.io/c/backpack-hero/api/v1/package-listing-index/"
-  steamFolderName: "Backpack Hero"
-  exeNames:
-    - "Backpack Hero.exe"
-    - "linux.x86_64"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "bh"
-    - "farlands"
-  packageLoader: "melonloader"
-  installRules:
-    - route: "Mods"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "UserData/ModManager"
-      defaultFileExtensions: []
-      trackingMethod: "subdir-no-flatten"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "UserLibs"
-      defaultFileExtensions:
-        - ".lib.dll"
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "MelonLoader"
-      defaultFileExtensions: []
-      trackingMethod: "state"
-      subRoutes:
-        - route: "Managed"
-          defaultFileExtensions:
-            - ".managed.dll"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "Libs"
-          defaultFileExtensions: []
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-      isDefaultLocation: false
-  relativeFileExclusions:
-    - "manifest.json"
-    - "icon.png"
-    - "README.md"
-    - "LICENCE"
+  - meta:
+      displayName: "Backpack Hero"
+      iconUrl: "BackpackHero.jpg"
+    internalFolderName: "BackpackHero"
+    dataFolderName: "Backpack Hero_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1970580"
+    settingsIdentifier: "BackpackHero"
+    packageIndex: "https://thunderstore.io/c/backpack-hero/api/v1/package-listing-index/"
+    steamFolderName: "Backpack Hero"
+    exeNames:
+      - "Backpack Hero.exe"
+      - "linux.x86_64"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "bh"
+      - "farlands"
+    packageLoader: "melonloader"
+    installRules:
+      - route: "Mods"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "UserData/ModManager"
+        defaultFileExtensions: []
+        trackingMethod: "subdir-no-flatten"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "UserLibs"
+        defaultFileExtensions:
+          - ".lib.dll"
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "MelonLoader"
+        defaultFileExtensions: []
+        trackingMethod: "state"
+        subRoutes:
+          - route: "Managed"
+            defaultFileExtensions:
+              - ".managed.dll"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "Libs"
+            defaultFileExtensions: []
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+        isDefaultLocation: false
+    relativeFileExclusions:
+      - "manifest.json"
+      - "icon.png"
+      - "README.md"
+      - "LICENCE"

--- a/games/data/generated/balatro.yml
+++ b/games/data/generated/balatro.yml
@@ -7,16 +7,22 @@ distributions:
   - platform: "steam"
     identifier: "2379780"
 r2modman:
-  internalFolderName: "Balatro"
-  dataFolderName: "Balatro_Data"
-  settingsIdentifier: "Balatro"
-  packageIndex: "https://thunderstore.io/c/balatro/api/v1/package-listing-index/"
-  steamFolderName: "Balatro"
-  exeNames:
-    - "Balatro.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "lovely"
-  installRules: []
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Balatro"
+      iconUrl: "Balatro.png"
+    internalFolderName: "Balatro"
+    dataFolderName: "Balatro_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2379780"
+    settingsIdentifier: "Balatro"
+    packageIndex: "https://thunderstore.io/c/balatro/api/v1/package-listing-index/"
+    steamFolderName: "Balatro"
+    exeNames:
+      - "Balatro.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "lovely"
+    installRules: []
+    relativeFileExclusions: null

--- a/games/data/generated/below-the-stone.yml
+++ b/games/data/generated/below-the-stone.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1170230"
 r2modman:
-  internalFolderName: "BelowTheStone"
-  dataFolderName: "Below The Stone_Data"
-  settingsIdentifier: "BelowTheStone"
-  packageIndex: "https://thunderstore.io/c/below-the-stone/api/v1/package-listing-index/"
-  steamFolderName: "Below The Stone"
-  exeNames:
-    - "Below The Stone.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "bts"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Below the Stone"
+      iconUrl: "BelowTheStone.png"
+    internalFolderName: "BelowTheStone"
+    dataFolderName: "Below The Stone_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1170230"
+    settingsIdentifier: "BelowTheStone"
+    packageIndex: "https://thunderstore.io/c/below-the-stone/api/v1/package-listing-index/"
+    steamFolderName: "Below The Stone"
+    exeNames:
+      - "Below The Stone.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "bts"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/betrayal-beach.yml
+++ b/games/data/generated/betrayal-beach.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2643810"
 r2modman:
-  internalFolderName: "BetrayalBeach"
-  dataFolderName: "Betrayal Beach_Data"
-  settingsIdentifier: "BetrayalBeach"
-  packageIndex: "https://thunderstore.io/c/betrayal-beach/api/v1/package-listing-index/"
-  steamFolderName: "Betrayal Beach"
-  exeNames:
-    - "Betrayal Beach.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Betrayal Beach"
+      iconUrl: "BetrayalBeach.png"
+    internalFolderName: "BetrayalBeach"
+    dataFolderName: "Betrayal Beach_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2643810"
+    settingsIdentifier: "BetrayalBeach"
+    packageIndex: "https://thunderstore.io/c/betrayal-beach/api/v1/package-listing-index/"
+    steamFolderName: "Betrayal Beach"
+    exeNames:
+      - "Betrayal Beach.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/bomb-rush-cyberfunk.yml
+++ b/games/data/generated/bomb-rush-cyberfunk.yml
@@ -11,44 +11,54 @@ distributions:
   - platform: "other"
     identifier: null
 r2modman:
-  internalFolderName: "BombRushCyberfunk"
-  dataFolderName: "Bomb Rush Cyberfunk_Data"
-  settingsIdentifier: "BombRushCyberfunk"
-  packageIndex: "https://thunderstore.io/c/bomb-rush-cyberfunk/api/v1/package-listing-index/"
-  steamFolderName: "BombRushCyberfunk"
-  exeNames:
-    - "Bomb Rush Cyberfunk.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "brc"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Bomb Rush Cyberfunk"
+      iconUrl: "BombRushCyberfunk.jpg"
+    internalFolderName: "BombRushCyberfunk"
+    dataFolderName: "Bomb Rush Cyberfunk_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1353230"
+      - platform: "xbox-game-pass"
+        identifier: "TeamReptile.BombRushCyberfunk"
+      - platform: "other"
+        identifier: null
+    settingsIdentifier: "BombRushCyberfunk"
+    packageIndex: "https://thunderstore.io/c/bomb-rush-cyberfunk/api/v1/package-listing-index/"
+    steamFolderName: "BombRushCyberfunk"
+    exeNames:
+      - "Bomb Rush Cyberfunk.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "brc"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/bonelab.yml
+++ b/games/data/generated/bonelab.yml
@@ -9,116 +9,124 @@ distributions:
   - platform: "oculus-store"
     identifier: null
 r2modman:
-  internalFolderName: "BONELAB"
-  dataFolderName: "BONELAB_Steam_Windows64"
-  settingsIdentifier: "BONELAB"
-  packageIndex: "https://thunderstore.io/c/bonelab/api/v1/package-listing-index/"
-  steamFolderName: "BONELAB"
-  exeNames:
-    - "BONELAB_Steam_Windows64.exe"
-    - "BONELAB_Oculus_Windows64.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "BL"
-  packageLoader: "melonloader"
-  installRules:
-    - route: "Mods"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "Plugins"
-      defaultFileExtensions:
-        - ".plugin.dll"
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "UserLibs"
-      defaultFileExtensions:
-        - ".lib.dll"
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "MelonLoader"
-      defaultFileExtensions: []
-      trackingMethod: "state"
-      subRoutes:
-        - route: "Managed"
-          defaultFileExtensions:
-            - ".managed.dll"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "Libs"
-          defaultFileExtensions: []
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-      isDefaultLocation: false
-    - route: "UserData"
-      defaultFileExtensions: []
-      trackingMethod: "state"
-      subRoutes:
-        - route: "CustomItems"
-          defaultFileExtensions:
-            - ".melon"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "CustomMaps"
-          defaultFileExtensions:
-            - ".bcm"
-            - ".cma"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "PlayerModels"
-          defaultFileExtensions:
-            - ".body"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "CustomLoadScreens"
-          defaultFileExtensions:
-            - ".load"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "Music"
-          defaultFileExtensions:
-            - ".wav"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "Food"
-          defaultFileExtensions:
-            - ".food"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "Scoreworks"
-          defaultFileExtensions:
-            - ".sw"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "CustomSkins"
-          defaultFileExtensions:
-            - ".png"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "Grenades"
-          defaultFileExtensions:
-            - ".grenade"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-      isDefaultLocation: false
-  relativeFileExclusions:
-    - "manifest.json"
-    - "icon.png"
-    - "README.md"
-    - "LICENCE"
+  - meta:
+      displayName: "BONELAB"
+      iconUrl: "BONELAB.jpg"
+    internalFolderName: "BONELAB"
+    dataFolderName: "BONELAB_Steam_Windows64"
+    distributions:
+      - platform: "steam"
+        identifier: "1592190"
+      - platform: "oculus-store"
+        identifier: null
+    settingsIdentifier: "BONELAB"
+    packageIndex: "https://thunderstore.io/c/bonelab/api/v1/package-listing-index/"
+    steamFolderName: "BONELAB"
+    exeNames:
+      - "BONELAB_Steam_Windows64.exe"
+      - "BONELAB_Oculus_Windows64.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "BL"
+    packageLoader: "melonloader"
+    installRules:
+      - route: "Mods"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "Plugins"
+        defaultFileExtensions:
+          - ".plugin.dll"
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "UserLibs"
+        defaultFileExtensions:
+          - ".lib.dll"
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "MelonLoader"
+        defaultFileExtensions: []
+        trackingMethod: "state"
+        subRoutes:
+          - route: "Managed"
+            defaultFileExtensions:
+              - ".managed.dll"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "Libs"
+            defaultFileExtensions: []
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+        isDefaultLocation: false
+      - route: "UserData"
+        defaultFileExtensions: []
+        trackingMethod: "state"
+        subRoutes:
+          - route: "CustomItems"
+            defaultFileExtensions:
+              - ".melon"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "CustomMaps"
+            defaultFileExtensions:
+              - ".bcm"
+              - ".cma"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "PlayerModels"
+            defaultFileExtensions:
+              - ".body"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "CustomLoadScreens"
+            defaultFileExtensions:
+              - ".load"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "Music"
+            defaultFileExtensions:
+              - ".wav"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "Food"
+            defaultFileExtensions:
+              - ".food"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "Scoreworks"
+            defaultFileExtensions:
+              - ".sw"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "CustomSkins"
+            defaultFileExtensions:
+              - ".png"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "Grenades"
+            defaultFileExtensions:
+              - ".grenade"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+        isDefaultLocation: false
+    relativeFileExclusions:
+      - "manifest.json"
+      - "icon.png"
+      - "README.md"
+      - "LICENCE"

--- a/games/data/generated/boneworks.yml
+++ b/games/data/generated/boneworks.yml
@@ -9,116 +9,124 @@ distributions:
   - platform: "oculus-store"
     identifier: null
 r2modman:
-  internalFolderName: "BONEWORKS"
-  dataFolderName: "BONEWORKS_Data"
-  settingsIdentifier: "BONEWORKS"
-  packageIndex: "https://thunderstore.io/c/boneworks/api/v1/package-listing-index/"
-  steamFolderName: "BONEWORKS/BONEWORKS"
-  exeNames:
-    - "BONEWORKS.exe"
-    - "Boneworks_Oculus_Windows64.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "BW"
-  packageLoader: "melonloader"
-  installRules:
-    - route: "Mods"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "Plugins"
-      defaultFileExtensions:
-        - ".plugin.dll"
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "UserLibs"
-      defaultFileExtensions:
-        - ".lib.dll"
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "MelonLoader"
-      defaultFileExtensions: []
-      trackingMethod: "state"
-      subRoutes:
-        - route: "Managed"
-          defaultFileExtensions:
-            - ".managed.dll"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "Libs"
-          defaultFileExtensions: []
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-      isDefaultLocation: false
-    - route: "UserData"
-      defaultFileExtensions: []
-      trackingMethod: "state"
-      subRoutes:
-        - route: "CustomItems"
-          defaultFileExtensions:
-            - ".melon"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "CustomMaps"
-          defaultFileExtensions:
-            - ".bcm"
-            - ".cma"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "PlayerModels"
-          defaultFileExtensions:
-            - ".body"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "CustomLoadScreens"
-          defaultFileExtensions:
-            - ".load"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "Music"
-          defaultFileExtensions:
-            - ".wav"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "Food"
-          defaultFileExtensions:
-            - ".food"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "Scoreworks"
-          defaultFileExtensions:
-            - ".sw"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "CustomSkins"
-          defaultFileExtensions:
-            - ".png"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "Grenades"
-          defaultFileExtensions:
-            - ".grenade"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-      isDefaultLocation: false
-  relativeFileExclusions:
-    - "manifest.json"
-    - "icon.png"
-    - "README.md"
-    - "LICENCE"
+  - meta:
+      displayName: "BONEWORKS"
+      iconUrl: "BONEWORKS.jpg"
+    internalFolderName: "BONEWORKS"
+    dataFolderName: "BONEWORKS_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "823500"
+      - platform: "oculus-store"
+        identifier: null
+    settingsIdentifier: "BONEWORKS"
+    packageIndex: "https://thunderstore.io/c/boneworks/api/v1/package-listing-index/"
+    steamFolderName: "BONEWORKS/BONEWORKS"
+    exeNames:
+      - "BONEWORKS.exe"
+      - "Boneworks_Oculus_Windows64.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "BW"
+    packageLoader: "melonloader"
+    installRules:
+      - route: "Mods"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "Plugins"
+        defaultFileExtensions:
+          - ".plugin.dll"
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "UserLibs"
+        defaultFileExtensions:
+          - ".lib.dll"
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "MelonLoader"
+        defaultFileExtensions: []
+        trackingMethod: "state"
+        subRoutes:
+          - route: "Managed"
+            defaultFileExtensions:
+              - ".managed.dll"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "Libs"
+            defaultFileExtensions: []
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+        isDefaultLocation: false
+      - route: "UserData"
+        defaultFileExtensions: []
+        trackingMethod: "state"
+        subRoutes:
+          - route: "CustomItems"
+            defaultFileExtensions:
+              - ".melon"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "CustomMaps"
+            defaultFileExtensions:
+              - ".bcm"
+              - ".cma"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "PlayerModels"
+            defaultFileExtensions:
+              - ".body"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "CustomLoadScreens"
+            defaultFileExtensions:
+              - ".load"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "Music"
+            defaultFileExtensions:
+              - ".wav"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "Food"
+            defaultFileExtensions:
+              - ".food"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "Scoreworks"
+            defaultFileExtensions:
+              - ".sw"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "CustomSkins"
+            defaultFileExtensions:
+              - ".png"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "Grenades"
+            defaultFileExtensions:
+              - ".grenade"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+        isDefaultLocation: false
+    relativeFileExclusions:
+      - "manifest.json"
+      - "icon.png"
+      - "README.md"
+      - "LICENCE"

--- a/games/data/generated/bopl-battle.yml
+++ b/games/data/generated/bopl-battle.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1686940"
 r2modman:
-  internalFolderName: "BoplBattle"
-  dataFolderName: "BoplBattle_Data"
-  settingsIdentifier: "BoplBattle"
-  packageIndex: "https://thunderstore.io/c/bopl-battle/api/v1/package-listing-index/"
-  steamFolderName: "Bopl Battle"
-  exeNames:
-    - "BoplBattle.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "bb"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Bopl Battle"
+      iconUrl: "BoplBattle.png"
+    internalFolderName: "BoplBattle"
+    dataFolderName: "BoplBattle_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1686940"
+    settingsIdentifier: "BoplBattle"
+    packageIndex: "https://thunderstore.io/c/bopl-battle/api/v1/package-listing-index/"
+    steamFolderName: "Bopl Battle"
+    exeNames:
+      - "BoplBattle.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "bb"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/brotato.yml
+++ b/games/data/generated/brotato.yml
@@ -7,21 +7,27 @@ distributions:
   - platform: "steam"
     identifier: "1942280"
 r2modman:
-  internalFolderName: "Brotato"
-  dataFolderName: ""
-  settingsIdentifier: "Brotato"
-  packageIndex: "https://thunderstore.io/c/brotato/api/v1/package-listing-index/"
-  steamFolderName: "Brotato"
-  exeNames:
-    - "Brotato.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "godotml"
-  installRules:
-    - route: "mods"
-      defaultFileExtensions: []
-      trackingMethod: "package-zip"
-      subRoutes: []
-      isDefaultLocation: true
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Brotato"
+      iconUrl: "brotato.jpg"
+    internalFolderName: "Brotato"
+    dataFolderName: ""
+    distributions:
+      - platform: "steam"
+        identifier: "1942280"
+    settingsIdentifier: "Brotato"
+    packageIndex: "https://thunderstore.io/c/brotato/api/v1/package-listing-index/"
+    steamFolderName: "Brotato"
+    exeNames:
+      - "Brotato.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "godotml"
+    installRules:
+      - route: "mods"
+        defaultFileExtensions: []
+        trackingMethod: "package-zip"
+        subRoutes: []
+        isDefaultLocation: true
+    relativeFileExclusions: null

--- a/games/data/generated/castle-story.yml
+++ b/games/data/generated/castle-story.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam-direct"
     identifier: "227860"
 r2modman:
-  internalFolderName: "CastleStory"
-  dataFolderName: "Castle Story_Data"
-  settingsIdentifier: "CastleStory"
-  packageIndex: "https://thunderstore.io/c/castle-story/api/v1/package-listing-index/"
-  steamFolderName: "Castle Story"
-  exeNames:
-    - "Castle Story.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "cs"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Castle Story"
+      iconUrl: "CastleStory.png"
+    internalFolderName: "CastleStory"
+    dataFolderName: "Castle Story_Data"
+    distributions:
+      - platform: "steam-direct"
+        identifier: "227860"
+    settingsIdentifier: "CastleStory"
+    packageIndex: "https://thunderstore.io/c/castle-story/api/v1/package-listing-index/"
+    steamFolderName: "Castle Story"
+    exeNames:
+      - "Castle Story.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "cs"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/cats-are-liquid.yml
+++ b/games/data/generated/cats-are-liquid.yml
@@ -9,48 +9,56 @@ distributions:
   - platform: "other"
     identifier: null
 r2modman:
-  internalFolderName: "CatsAreLiquidABP"
-  dataFolderName: "CaL-ABP-Windows_Data"
-  settingsIdentifier: "CatsAreLiquidABP"
-  packageIndex: "https://thunderstore.io/c/cats-are-liquid/api/v1/package-listing-index/"
-  steamFolderName: "Cats are Liquid - A Better Place"
-  exeNames:
-    - "CaL-ABP-Windows.exe"
-    - "CaL-ABP-Linux.x86_64"
-    - "CaL-ABP-macOS.app"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "calabp"
-    - "cal"
-    - "abp"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Cats are Liquid - A Better Place"
+      iconUrl: "CatsAreLiquidABP.jpg"
+    internalFolderName: "CatsAreLiquidABP"
+    dataFolderName: "CaL-ABP-Windows_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1188080"
+      - platform: "other"
+        identifier: null
+    settingsIdentifier: "CatsAreLiquidABP"
+    packageIndex: "https://thunderstore.io/c/cats-are-liquid/api/v1/package-listing-index/"
+    steamFolderName: "Cats are Liquid - A Better Place"
+    exeNames:
+      - "CaL-ABP-Windows.exe"
+      - "CaL-ABP-Linux.x86_64"
+      - "CaL-ABP-macOS.app"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "calabp"
+      - "cal"
+      - "abp"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/chrono-ark.yml
+++ b/games/data/generated/chrono-ark.yml
@@ -7,43 +7,49 @@ distributions:
   - platform: "steam"
     identifier: "1188930"
 r2modman:
-  internalFolderName: "ChronoArk"
-  dataFolderName: "ChronoArk_Data"
-  settingsIdentifier: "ChronoArk"
-  packageIndex: "https://thunderstore.io/c/chrono-ark/api/v1/package-listing-index/"
-  steamFolderName: "Chrono Ark/x64/Master"
-  exeNames:
-    - "ChronoArk.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Chrono Ark"
+      iconUrl: "ChronoArk.jpg"
+    internalFolderName: "ChronoArk"
+    dataFolderName: "ChronoArk_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1188930"
+    settingsIdentifier: "ChronoArk"
+    packageIndex: "https://thunderstore.io/c/chrono-ark/api/v1/package-listing-index/"
+    steamFolderName: "Chrono Ark/x64/Master"
+    exeNames:
+      - "ChronoArk.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/cities-skylines-ii.yml
+++ b/games/data/generated/cities-skylines-ii.yml
@@ -9,44 +9,52 @@ distributions:
   - platform: "xbox-game-pass"
     identifier: "ParadoxInteractive.CitiesSkylinesII-PCEdition"
 r2modman:
-  internalFolderName: "CitiesSkylines2"
-  dataFolderName: "CitiesSkylines2_Data"
-  settingsIdentifier: "CitiesSkylines2"
-  packageIndex: "https://thunderstore.io/c/cities-skylines-ii/api/v1/package-listing-index/"
-  steamFolderName: "Cities Skylines II"
-  exeNames:
-    - "Cities2.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "cs2"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Cities: Skylines II"
+      iconUrl: "CitiesSkylines2.png"
+    internalFolderName: "CitiesSkylines2"
+    dataFolderName: "CitiesSkylines2_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "949230"
+      - platform: "xbox-game-pass"
+        identifier: "ParadoxInteractive.CitiesSkylinesII-PCEdition"
+    settingsIdentifier: "CitiesSkylines2"
+    packageIndex: "https://thunderstore.io/c/cities-skylines-ii/api/v1/package-listing-index/"
+    steamFolderName: "Cities Skylines II"
+    exeNames:
+      - "Cities2.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "cs2"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/content-warning.yml
+++ b/games/data/generated/content-warning.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2881650"
 r2modman:
-  internalFolderName: "ContentWarning"
-  dataFolderName: "Content Warning_Data"
-  settingsIdentifier: "ContentWarning"
-  packageIndex: "https://thunderstore.io/c/content-warning/api/v1/package-listing-index/"
-  steamFolderName: "Content Warning"
-  exeNames:
-    - "Content Warning.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "cw"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Content Warning"
+      iconUrl: "ContentWarning.png"
+    internalFolderName: "ContentWarning"
+    dataFolderName: "Content Warning_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2881650"
+    settingsIdentifier: "ContentWarning"
+    packageIndex: "https://thunderstore.io/c/content-warning/api/v1/package-listing-index/"
+    steamFolderName: "Content Warning"
+    exeNames:
+      - "Content Warning.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "cw"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/core-keeper.yml
+++ b/games/data/generated/core-keeper.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1621690"
 r2modman:
-  internalFolderName: "CoreKeeper"
-  dataFolderName: "CoreKeeper_Data"
-  settingsIdentifier: "CoreKeeper"
-  packageIndex: "https://thunderstore.io/c/core-keeper/api/v1/package-listing-index/"
-  steamFolderName: "Core Keeper"
-  exeNames:
-    - "CoreKeeper.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "ck"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Core Keeper"
+      iconUrl: "CoreKeeper.png"
+    internalFolderName: "CoreKeeper"
+    dataFolderName: "CoreKeeper_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1621690"
+    settingsIdentifier: "CoreKeeper"
+    packageIndex: "https://thunderstore.io/c/core-keeper/api/v1/package-listing-index/"
+    steamFolderName: "Core Keeper"
+    exeNames:
+      - "CoreKeeper.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "ck"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/cult-of-the-lamb.yml
+++ b/games/data/generated/cult-of-the-lamb.yml
@@ -9,44 +9,52 @@ distributions:
   - platform: "other"
     identifier: null
 r2modman:
-  internalFolderName: "COTL"
-  dataFolderName: "Cult Of The Lamb_Data"
-  settingsIdentifier: "COTL"
-  packageIndex: "https://thunderstore.io/c/cult-of-the-lamb/api/v1/package-listing-index/"
-  steamFolderName: "Cult of the Lamb"
-  exeNames:
-    - "Cult Of The Lamb.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "cotl"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Cult of the Lamb"
+      iconUrl: "Cotl.jpg"
+    internalFolderName: "COTL"
+    dataFolderName: "Cult Of The Lamb_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1313140"
+      - platform: "other"
+        identifier: null
+    settingsIdentifier: "COTL"
+    packageIndex: "https://thunderstore.io/c/cult-of-the-lamb/api/v1/package-listing-index/"
+    steamFolderName: "Cult of the Lamb"
+    exeNames:
+      - "Cult Of The Lamb.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "cotl"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/dale-dawson-stationery-supplies.yml
+++ b/games/data/generated/dale-dawson-stationery-supplies.yml
@@ -7,17 +7,23 @@ distributions:
   - platform: "steam"
     identifier: "2920570"
 r2modman:
-  internalFolderName: "DaleAndDawson"
-  dataFolderName: "DDSS_Data"
-  settingsIdentifier: "DaleAndDawson"
-  packageIndex: "https://thunderstore.io/c/dale-dawson-stationery-supplies/api/v1/package-listing-index/"
-  steamFolderName: "Dale&Dawson"
-  exeNames:
-    - "DDSS.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "recursive-melonloader"
-  installRules: []
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Dale & Dawson Stationery Supplies"
+      iconUrl: "DaleAndDawson.png"
+    internalFolderName: "DaleAndDawson"
+    dataFolderName: "DDSS_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2920570"
+    settingsIdentifier: "DaleAndDawson"
+    packageIndex: "https://thunderstore.io/c/dale-dawson-stationery-supplies/api/v1/package-listing-index/"
+    steamFolderName: "Dale&Dawson"
+    exeNames:
+      - "DDSS.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "recursive-melonloader"
+    installRules: []
+    relativeFileExclusions: null

--- a/games/data/generated/deep-rock-galactic-survivor.yml
+++ b/games/data/generated/deep-rock-galactic-survivor.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2321470"
 r2modman:
-  internalFolderName: "DeepRockGalacticSurvivor"
-  dataFolderName: "DRG Survivor_Data"
-  settingsIdentifier: "DeepRockGalacticSurvivor"
-  packageIndex: "https://thunderstore.io/c/deep-rock-galactic-survivor/api/v1/package-listing-index/"
-  steamFolderName: "Deep Rock Survivor"
-  exeNames:
-    - "DRG Survivor.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Deep Rock Galactic: Survivor"
+      iconUrl: "DeepRockGalacticSurvivor.png"
+    internalFolderName: "DeepRockGalacticSurvivor"
+    dataFolderName: "DRG Survivor_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2321470"
+    settingsIdentifier: "DeepRockGalacticSurvivor"
+    packageIndex: "https://thunderstore.io/c/deep-rock-galactic-survivor/api/v1/package-listing-index/"
+    steamFolderName: "Deep Rock Survivor"
+    exeNames:
+      - "DRG Survivor.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/disco-elysium.yml
+++ b/games/data/generated/disco-elysium.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "632470"
 r2modman:
-  internalFolderName: "DiscoElysium"
-  dataFolderName: "disco_Data"
-  settingsIdentifier: "Disco Elysium"
-  packageIndex: "https://thunderstore.io/c/disco-elysium/api/v1/package-listing-index/"
-  steamFolderName: "Disco Elysium"
-  exeNames:
-    - "disco.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "de"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Disco Elysium"
+      iconUrl: "DiscoElysium.webp"
+    internalFolderName: "DiscoElysium"
+    dataFolderName: "disco_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "632470"
+    settingsIdentifier: "Disco Elysium"
+    packageIndex: "https://thunderstore.io/c/disco-elysium/api/v1/package-listing-index/"
+    steamFolderName: "Disco Elysium"
+    exeNames:
+      - "disco.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "de"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/distance.yml
+++ b/games/data/generated/distance.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "233610"
 r2modman:
-  internalFolderName: "Distance"
-  dataFolderName: "Distance_Data"
-  settingsIdentifier: "Distance"
-  packageIndex: "https://thunderstore.io/c/distance/api/v1/package-listing-index/"
-  steamFolderName: "Distance"
-  exeNames:
-    - "Distance.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Distance"
+      iconUrl: "Distance.png"
+    internalFolderName: "Distance"
+    dataFolderName: "Distance_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "233610"
+    settingsIdentifier: "Distance"
+    packageIndex: "https://thunderstore.io/c/distance/api/v1/package-listing-index/"
+    steamFolderName: "Distance"
+    exeNames:
+      - "Distance.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/dome-keeper.yml
+++ b/games/data/generated/dome-keeper.yml
@@ -7,22 +7,28 @@ distributions:
   - platform: "steam"
     identifier: "1637320"
 r2modman:
-  internalFolderName: "DomeKeeper"
-  dataFolderName: ""
-  settingsIdentifier: "DomeKeeper"
-  packageIndex: "https://thunderstore.io/c/dome-keeper/api/v1/package-listing-index/"
-  steamFolderName: "Dome Keeper"
-  exeNames:
-    - "domekeeper.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "dk"
-  packageLoader: "godotml"
-  installRules:
-    - route: "mods"
-      defaultFileExtensions: []
-      trackingMethod: "package-zip"
-      subRoutes: []
-      isDefaultLocation: true
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Dome Keeper"
+      iconUrl: "dome-keeper.jpg"
+    internalFolderName: "DomeKeeper"
+    dataFolderName: ""
+    distributions:
+      - platform: "steam"
+        identifier: "1637320"
+    settingsIdentifier: "DomeKeeper"
+    packageIndex: "https://thunderstore.io/c/dome-keeper/api/v1/package-listing-index/"
+    steamFolderName: "Dome Keeper"
+    exeNames:
+      - "domekeeper.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "dk"
+    packageLoader: "godotml"
+    installRules:
+      - route: "mods"
+        defaultFileExtensions: []
+        trackingMethod: "package-zip"
+        subRoutes: []
+        isDefaultLocation: true
+    relativeFileExclusions: null

--- a/games/data/generated/dredge.yml
+++ b/games/data/generated/dredge.yml
@@ -7,43 +7,49 @@ distributions:
   - platform: "steam"
     identifier: "1562430"
 r2modman:
-  internalFolderName: "Dredge"
-  dataFolderName: "DREDGE_Data"
-  settingsIdentifier: "Dredge"
-  packageIndex: "https://thunderstore.io/c/dredge/api/v1/package-listing-index/"
-  steamFolderName: "DREDGE"
-  exeNames:
-    - "DREDGE.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "DREDGE"
+      iconUrl: "Dredge.png"
+    internalFolderName: "Dredge"
+    dataFolderName: "DREDGE_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1562430"
+    settingsIdentifier: "Dredge"
+    packageIndex: "https://thunderstore.io/c/dredge/api/v1/package-listing-index/"
+    steamFolderName: "DREDGE"
+    exeNames:
+      - "DREDGE.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/dusk.yml
+++ b/games/data/generated/dusk.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "519860"
 r2modman:
-  internalFolderName: "DUSK"
-  dataFolderName: "Dusk_Data"
-  settingsIdentifier: "DUSK"
-  packageIndex: "https://thunderstore.io/c/dusk/api/v1/package-listing-index/"
-  steamFolderName: "Dusk"
-  exeNames:
-    - "Dusk.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "DUSK"
+      iconUrl: "DUSK.png"
+    internalFolderName: "DUSK"
+    dataFolderName: "Dusk_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "519860"
+    settingsIdentifier: "DUSK"
+    packageIndex: "https://thunderstore.io/c/dusk/api/v1/package-listing-index/"
+    steamFolderName: "Dusk"
+    exeNames:
+      - "Dusk.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/dyson-sphere-program.yml
+++ b/games/data/generated/dyson-sphere-program.yml
@@ -9,44 +9,52 @@ distributions:
   - platform: "xbox-game-pass"
     identifier: "GameraGame.DysonSphereProgram"
 r2modman:
-  internalFolderName: "DysonSphereProgram"
-  dataFolderName: "DSPGAME_Data"
-  settingsIdentifier: "DysonSphereProgram"
-  packageIndex: "https://thunderstore.io/c/dyson-sphere-program/api/v1/package-listing-index/"
-  steamFolderName: "Dyson Sphere Program"
-  exeNames:
-    - "DSPGAME.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "DSP"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Dyson Sphere Program"
+      iconUrl: "DysonSphereProgram.png"
+    internalFolderName: "DysonSphereProgram"
+    dataFolderName: "DSPGAME_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1366540"
+      - platform: "xbox-game-pass"
+        identifier: "GameraGame.DysonSphereProgram"
+    settingsIdentifier: "DysonSphereProgram"
+    packageIndex: "https://thunderstore.io/c/dyson-sphere-program/api/v1/package-listing-index/"
+    steamFolderName: "Dyson Sphere Program"
+    exeNames:
+      - "DSPGAME.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "DSP"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/ena-dream-bbq.yml
+++ b/games/data/generated/ena-dream-bbq.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2134320"
 r2modman:
-  internalFolderName: "ENADreamBBQ"
-  dataFolderName: "ENA-4-DreamBBQ_Data"
-  settingsIdentifier: "ENADreamBBQ"
-  packageIndex: "https://thunderstore.io/c/ena-dream-bbq/api/v1/package-listing-index/"
-  steamFolderName: "ENA-4-DreamBBQ"
-  exeNames:
-    - "ENA-4-DreamBBQ.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "edbbq"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "ENA: Dream BBQ"
+      iconUrl: "ENADreamBBQ.png"
+    internalFolderName: "ENADreamBBQ"
+    dataFolderName: "ENA-4-DreamBBQ_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2134320"
+    settingsIdentifier: "ENADreamBBQ"
+    packageIndex: "https://thunderstore.io/c/ena-dream-bbq/api/v1/package-listing-index/"
+    steamFolderName: "ENA-4-DreamBBQ"
+    exeNames:
+      - "ENA-4-DreamBBQ.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "edbbq"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/enter-the-gungeon.yml
+++ b/games/data/generated/enter-the-gungeon.yml
@@ -11,44 +11,54 @@ distributions:
   - platform: "other"
     identifier: null
 r2modman:
-  internalFolderName: "ETG"
-  dataFolderName: "EtG_Data"
-  settingsIdentifier: "EnterTheGungeon"
-  packageIndex: "https://thunderstore.io/c/enter-the-gungeon/api/v1/package-listing-index/"
-  steamFolderName: "Enter the Gungeon"
-  exeNames:
-    - "EtG.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "etg"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Enter the Gungeon"
+      iconUrl: "EnterTheGungeon.jpg"
+    internalFolderName: "ETG"
+    dataFolderName: "EtG_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "311690"
+      - platform: "epic-games-store"
+        identifier: "Garlic"
+      - platform: "other"
+        identifier: null
+    settingsIdentifier: "EnterTheGungeon"
+    packageIndex: "https://thunderstore.io/c/enter-the-gungeon/api/v1/package-listing-index/"
+    steamFolderName: "Enter the Gungeon"
+    exeNames:
+      - "EtG.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "etg"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/erenshor.yml
+++ b/games/data/generated/erenshor.yml
@@ -7,43 +7,49 @@ distributions:
   - platform: "steam"
     identifier: "2382520"
 r2modman:
-  internalFolderName: "Erenshor"
-  dataFolderName: "Erenshor_Data"
-  settingsIdentifier: "Erenshor"
-  packageIndex: "https://thunderstore.io/c/erenshor/api/v1/package-listing-index/"
-  steamFolderName: "Erenshor"
-  exeNames:
-    - "Erenshor.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Erenshor"
+      iconUrl: "Erenshor.jpg"
+    internalFolderName: "Erenshor"
+    dataFolderName: "Erenshor_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2382520"
+    settingsIdentifier: "Erenshor"
+    packageIndex: "https://thunderstore.io/c/erenshor/api/v1/package-listing-index/"
+    steamFolderName: "Erenshor"
+    exeNames:
+      - "Erenshor.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/five-nights-at-freddys-into-the-pit.yml
+++ b/games/data/generated/five-nights-at-freddys-into-the-pit.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2638370"
 r2modman:
-  internalFolderName: "FiveNightsAtFreddysIntoThePit"
-  dataFolderName: "Five Nights at Freddy's Into the Pit_Data"
-  settingsIdentifier: "FiveNightsAtFreddysIntoThePit"
-  packageIndex: "https://thunderstore.io/c/five-nights-at-freddys-into-the-pit/api/v1/package-listing-index/"
-  steamFolderName: "Five Nights at Freddy's Into the Pit"
-  exeNames:
-    - "Five Nights at Freddy's Into the Pit.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Five Nights at Freddy's: Into the Pit"
+      iconUrl: "FiveNightsAtFreddysIntoThePit.png"
+    internalFolderName: "FiveNightsAtFreddysIntoThePit"
+    dataFolderName: "Five Nights at Freddy's Into the Pit_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2638370"
+    settingsIdentifier: "FiveNightsAtFreddysIntoThePit"
+    packageIndex: "https://thunderstore.io/c/five-nights-at-freddys-into-the-pit/api/v1/package-listing-index/"
+    steamFolderName: "Five Nights at Freddy's Into the Pit"
+    exeNames:
+      - "Five Nights at Freddy's Into the Pit.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/for-the-king.yml
+++ b/games/data/generated/for-the-king.yml
@@ -9,44 +9,52 @@ distributions:
   - platform: "epic-games-store"
     identifier: "Discus"
 r2modman:
-  internalFolderName: "ForTheKing"
-  dataFolderName: "FTK_Data"
-  settingsIdentifier: "ForTheKing"
-  packageIndex: "https://thunderstore.io/c/for-the-king/api/v1/package-listing-index/"
-  steamFolderName: "For The King"
-  exeNames:
-    - "FTK.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "ftk"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "For The King"
+      iconUrl: "ForTheKing.png"
+    internalFolderName: "ForTheKing"
+    dataFolderName: "FTK_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "527230"
+      - platform: "epic-games-store"
+        identifier: "Discus"
+    settingsIdentifier: "ForTheKing"
+    packageIndex: "https://thunderstore.io/c/for-the-king/api/v1/package-listing-index/"
+    steamFolderName: "For The King"
+    exeNames:
+      - "FTK.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "ftk"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/gang-beasts.yml
+++ b/games/data/generated/gang-beasts.yml
@@ -7,17 +7,23 @@ distributions:
   - platform: "steam"
     identifier: "285900"
 r2modman:
-  internalFolderName: "GangBeasts"
-  dataFolderName: "Gang Beasts_Data"
-  settingsIdentifier: "GangBeasts"
-  packageIndex: "https://thunderstore.io/c/gang-beasts/api/v1/package-listing-index/"
-  steamFolderName: "Gang Beasts"
-  exeNames:
-    - "Gang Beasts.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "gb"
-  packageLoader: "recursive-melonloader"
-  installRules: []
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Gang Beasts"
+      iconUrl: "GangBeasts.png"
+    internalFolderName: "GangBeasts"
+    dataFolderName: "Gang Beasts_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "285900"
+    settingsIdentifier: "GangBeasts"
+    packageIndex: "https://thunderstore.io/c/gang-beasts/api/v1/package-listing-index/"
+    steamFolderName: "Gang Beasts"
+    exeNames:
+      - "Gang Beasts.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "gb"
+    packageLoader: "recursive-melonloader"
+    installRules: []
+    relativeFileExclusions: null

--- a/games/data/generated/garfield-kart-furious-racing.yml
+++ b/games/data/generated/garfield-kart-furious-racing.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1085510"
 r2modman:
-  internalFolderName: "GarfieldKartFuriousRacing"
-  dataFolderName: "GarfieldKartFuriousRacing_Data"
-  settingsIdentifier: "GarfieldKartFuriousRacing"
-  packageIndex: "https://thunderstore.io/c/garfield-kart-furious-racing/api/v1/package-listing-index/"
-  steamFolderName: "Garfield Kart - Furious Racing"
-  exeNames:
-    - "Garfield Kart Furious Racing.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "gkfr"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Garfield Kart - Furious Racing"
+      iconUrl: "garfield-kart-furious-racing.png"
+    internalFolderName: "GarfieldKartFuriousRacing"
+    dataFolderName: "GarfieldKartFuriousRacing_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1085510"
+    settingsIdentifier: "GarfieldKartFuriousRacing"
+    packageIndex: "https://thunderstore.io/c/garfield-kart-furious-racing/api/v1/package-listing-index/"
+    steamFolderName: "Garfield Kart - Furious Racing"
+    exeNames:
+      - "Garfield Kart Furious Racing.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "gkfr"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/gatekeeper.yml
+++ b/games/data/generated/gatekeeper.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2106670"
 r2modman:
-  internalFolderName: "Gatekeeper"
-  dataFolderName: "Gatekeeper_Data"
-  settingsIdentifier: "Gatekeeper"
-  packageIndex: "https://thunderstore.io/c/gatekeeper/api/v1/package-listing-index/"
-  steamFolderName: "Gatekeeper"
-  exeNames:
-    - "Gatekeeper.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "gk"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Gatekeeper"
+      iconUrl: "Gatekeeper.png"
+    internalFolderName: "Gatekeeper"
+    dataFolderName: "Gatekeeper_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2106670"
+    settingsIdentifier: "Gatekeeper"
+    packageIndex: "https://thunderstore.io/c/gatekeeper/api/v1/package-listing-index/"
+    steamFolderName: "Gatekeeper"
+    exeNames:
+      - "Gatekeeper.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "gk"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/gladio-mori.yml
+++ b/games/data/generated/gladio-mori.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2689120"
 r2modman:
-  internalFolderName: "GladioMori"
-  dataFolderName: "Gladio Mori_Data"
-  settingsIdentifier: "GladioMori"
-  packageIndex: "https://thunderstore.io/c/gladio-mori/api/v1/package-listing-index/"
-  steamFolderName: "Gladio Mori"
-  exeNames:
-    - "Gladio Mori.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "gm"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Gladio Mori"
+      iconUrl: "GladioMori.png"
+    internalFolderName: "GladioMori"
+    dataFolderName: "Gladio Mori_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2689120"
+    settingsIdentifier: "GladioMori"
+    packageIndex: "https://thunderstore.io/c/gladio-mori/api/v1/package-listing-index/"
+    steamFolderName: "Gladio Mori"
+    exeNames:
+      - "Gladio Mori.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "gm"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/gloomwood.yml
+++ b/games/data/generated/gloomwood.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1150760"
 r2modman:
-  internalFolderName: "Gloomwood"
-  dataFolderName: "Gloomwood_Data"
-  settingsIdentifier: "Gloomwood"
-  packageIndex: "https://thunderstore.io/c/gloomwood/api/v1/package-listing-index/"
-  steamFolderName: "Gloomwood"
-  exeNames:
-    - "Gloomwood.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "gw"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Gloomwood"
+      iconUrl: "Gloomwood.png"
+    internalFolderName: "Gloomwood"
+    dataFolderName: "Gloomwood_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1150760"
+    settingsIdentifier: "Gloomwood"
+    packageIndex: "https://thunderstore.io/c/gloomwood/api/v1/package-listing-index/"
+    steamFolderName: "Gloomwood"
+    exeNames:
+      - "Gloomwood.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "gw"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/goodbye-volcano-high.yml
+++ b/games/data/generated/goodbye-volcano-high.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1310330"
 r2modman:
-  internalFolderName: "GoodbyeVolcanoHigh"
-  dataFolderName: "Goodbye Volcano High_Data"
-  settingsIdentifier: "GoodbyeVolcanoHigh"
-  packageIndex: "https://thunderstore.io/c/goodbye-volcano-high/api/v1/package-listing-index/"
-  steamFolderName: "Goodbye Volcano High"
-  exeNames:
-    - "Goodbye Volcano High.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Goodbye Volcano High"
+      iconUrl: "GoodbyeVolcanoHigh.png"
+    internalFolderName: "GoodbyeVolcanoHigh"
+    dataFolderName: "Goodbye Volcano High_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1310330"
+    settingsIdentifier: "GoodbyeVolcanoHigh"
+    packageIndex: "https://thunderstore.io/c/goodbye-volcano-high/api/v1/package-listing-index/"
+    steamFolderName: "Goodbye Volcano High"
+    exeNames:
+      - "Goodbye Volcano High.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/gorebox.yml
+++ b/games/data/generated/gorebox.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2027330"
 r2modman:
-  internalFolderName: "GoreBox"
-  dataFolderName: "GoreBox_Data"
-  settingsIdentifier: "GoreBox"
-  packageIndex: "https://thunderstore.io/c/gorebox/api/v1/package-listing-index/"
-  steamFolderName: "GoreBox"
-  exeNames:
-    - "GoreBox.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "GoreBox"
+      iconUrl: "GoreBox.png"
+    internalFolderName: "GoreBox"
+    dataFolderName: "GoreBox_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2027330"
+    settingsIdentifier: "GoreBox"
+    packageIndex: "https://thunderstore.io/c/gorebox/api/v1/package-listing-index/"
+    steamFolderName: "GoreBox"
+    exeNames:
+      - "GoreBox.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/green-hell-vr.yml
+++ b/games/data/generated/green-hell-vr.yml
@@ -9,44 +9,52 @@ distributions:
   - platform: "oculus-store"
     identifier: null
 r2modman:
-  internalFolderName: "GreenHellVR"
-  dataFolderName: "GHVR_Data"
-  settingsIdentifier: "GreenHellVR"
-  packageIndex: "https://thunderstore.io/c/green-hell-vr/api/v1/package-listing-index/"
-  steamFolderName: "Green Hell VR"
-  exeNames:
-    - "GHVR.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "ghvr"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Green Hell VR"
+      iconUrl: "GreenHellVR.png"
+    internalFolderName: "GreenHellVR"
+    dataFolderName: "GHVR_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1782330"
+      - platform: "oculus-store"
+        identifier: null
+    settingsIdentifier: "GreenHellVR"
+    packageIndex: "https://thunderstore.io/c/green-hell-vr/api/v1/package-listing-index/"
+    steamFolderName: "Green Hell VR"
+    exeNames:
+      - "GHVR.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "ghvr"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/gtfo.yml
+++ b/games/data/generated/gtfo.yml
@@ -7,53 +7,59 @@ distributions:
   - platform: "steam"
     identifier: "493520"
 r2modman:
-  internalFolderName: "GTFO"
-  dataFolderName: "GTFO_Data"
-  settingsIdentifier: "GTFO"
-  packageIndex: "https://thunderstore.io/c/gtfo/api/v1/package-listing-index/"
-  steamFolderName: "GTFO"
-  exeNames:
-    - "GTFO.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/GameData"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/Assets"
-      defaultFileExtensions: []
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "GTFO"
+      iconUrl: "GTFO.jpg"
+    internalFolderName: "GTFO"
+    dataFolderName: "GTFO_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "493520"
+    settingsIdentifier: "GTFO"
+    packageIndex: "https://thunderstore.io/c/gtfo/api/v1/package-listing-index/"
+    steamFolderName: "GTFO"
+    exeNames:
+      - "GTFO.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/GameData"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/Assets"
+        defaultFileExtensions: []
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/h3vr.yml
+++ b/games/data/generated/h3vr.yml
@@ -7,52 +7,58 @@ distributions:
   - platform: "steam"
     identifier: "450540"
 r2modman:
-  internalFolderName: "H3VR"
-  dataFolderName: "h3vr_Data"
-  settingsIdentifier: "H3VR"
-  packageIndex: "https://thunderstore.io/c/h3vr/api/v1/package-listing-index/"
-  steamFolderName: "H3VR"
-  exeNames:
-    - "h3vr.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "Hot Dogs, Horseshoes & Hand Grenades"
-    - "Hot Dogs, Horseshoes and Hand Grenades"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/Sideloader"
-      defaultFileExtensions:
-        - ".hotmod"
-        - ".h3mod"
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "H3VR"
+      iconUrl: "H3VR.png"
+    internalFolderName: "H3VR"
+    dataFolderName: "h3vr_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "450540"
+    settingsIdentifier: "H3VR"
+    packageIndex: "https://thunderstore.io/c/h3vr/api/v1/package-listing-index/"
+    steamFolderName: "H3VR"
+    exeNames:
+      - "h3vr.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "Hot Dogs, Horseshoes & Hand Grenades"
+      - "Hot Dogs, Horseshoes and Hand Grenades"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/Sideloader"
+        defaultFileExtensions:
+          - ".hotmod"
+          - ".h3mod"
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/hades-ii.yml
+++ b/games/data/generated/hades-ii.yml
@@ -9,17 +9,25 @@ distributions:
   - platform: "epic-games-store"
     identifier: "07c634c7291a49b5b2455e14b9a83950"
 r2modman:
-  internalFolderName: "HadesII"
-  dataFolderName: ""
-  settingsIdentifier: "HadesII"
-  packageIndex: "https://thunderstore.io/c/hades-ii/api/v1/package-listing-index/"
-  steamFolderName: "Hades II/Ship"
-  exeNames:
-    - "Hades2.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "h2"
-  packageLoader: "returnofmodding"
-  installRules: []
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Hades II"
+      iconUrl: "Hades2.png"
+    internalFolderName: "HadesII"
+    dataFolderName: ""
+    distributions:
+      - platform: "steam"
+        identifier: "1145350"
+      - platform: "epic-games-store"
+        identifier: "07c634c7291a49b5b2455e14b9a83950"
+    settingsIdentifier: "HadesII"
+    packageIndex: "https://thunderstore.io/c/hades-ii/api/v1/package-listing-index/"
+    steamFolderName: "Hades II/Ship"
+    exeNames:
+      - "Hades2.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "h2"
+    packageLoader: "returnofmodding"
+    installRules: []
+    relativeFileExclusions: null

--- a/games/data/generated/hard-bullet.yml
+++ b/games/data/generated/hard-bullet.yml
@@ -7,60 +7,66 @@ distributions:
   - platform: "steam"
     identifier: "1294760"
 r2modman:
-  internalFolderName: "HardBullet"
-  dataFolderName: "Hard Bullet_Data"
-  settingsIdentifier: "HardBullet"
-  packageIndex: "https://thunderstore.io/c/hard-bullet/api/v1/package-listing-index/"
-  steamFolderName: "Hard Bullet"
-  exeNames:
-    - "Hard Bullet.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "hb"
-  packageLoader: "melonloader"
-  installRules:
-    - route: "Mods"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "UserData/ModManager"
-      defaultFileExtensions: []
-      trackingMethod: "subdir-no-flatten"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "UserLibs"
-      defaultFileExtensions:
-        - ".lib.dll"
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "MelonLoader"
-      defaultFileExtensions: []
-      trackingMethod: "state"
-      subRoutes:
-        - route: "Managed"
-          defaultFileExtensions:
-            - ".managed.dll"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "Libs"
-          defaultFileExtensions: []
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-      isDefaultLocation: false
-    - route: "UserData/CustomNPCs"
-      defaultFileExtensions:
-        - ".npc"
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions:
-    - "manifest.json"
-    - "icon.png"
-    - "README.md"
-    - "LICENCE"
+  - meta:
+      displayName: "Hard Bullet"
+      iconUrl: "HardBullet.jpg"
+    internalFolderName: "HardBullet"
+    dataFolderName: "Hard Bullet_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1294760"
+    settingsIdentifier: "HardBullet"
+    packageIndex: "https://thunderstore.io/c/hard-bullet/api/v1/package-listing-index/"
+    steamFolderName: "Hard Bullet"
+    exeNames:
+      - "Hard Bullet.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "hb"
+    packageLoader: "melonloader"
+    installRules:
+      - route: "Mods"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "UserData/ModManager"
+        defaultFileExtensions: []
+        trackingMethod: "subdir-no-flatten"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "UserLibs"
+        defaultFileExtensions:
+          - ".lib.dll"
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "MelonLoader"
+        defaultFileExtensions: []
+        trackingMethod: "state"
+        subRoutes:
+          - route: "Managed"
+            defaultFileExtensions:
+              - ".managed.dll"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "Libs"
+            defaultFileExtensions: []
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+        isDefaultLocation: false
+      - route: "UserData/CustomNPCs"
+        defaultFileExtensions:
+          - ".npc"
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions:
+      - "manifest.json"
+      - "icon.png"
+      - "README.md"
+      - "LICENCE"

--- a/games/data/generated/hard-time-3.yml
+++ b/games/data/generated/hard-time-3.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "3009850"
 r2modman:
-  internalFolderName: "HardTime3"
-  dataFolderName: "Hard Time III_Data"
-  settingsIdentifier: "HardTime3"
-  packageIndex: "https://thunderstore.io/c/hard-time-3/api/v1/package-listing-index/"
-  steamFolderName: "Hard Time III"
-  exeNames:
-    - "Hard Time III.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Hard Time III"
+      iconUrl: "HardTime3.png"
+    internalFolderName: "HardTime3"
+    dataFolderName: "Hard Time III_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "3009850"
+    settingsIdentifier: "HardTime3"
+    packageIndex: "https://thunderstore.io/c/hard-time-3/api/v1/package-listing-index/"
+    steamFolderName: "Hard Time III"
+    exeNames:
+      - "Hard Time III.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/hotds.yml
+++ b/games/data/generated/hotds.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "283160"
 r2modman:
-  internalFolderName: "HOTDS"
-  dataFolderName: "dyingsun_Data"
-  settingsIdentifier: "HOTDS"
-  packageIndex: "https://thunderstore.io/c/hotds/api/v1/package-listing-index/"
-  steamFolderName: "DyingSun"
-  exeNames:
-    - "dyingsun.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "hotds"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "House of the Dying Sun"
+      iconUrl: "HOTDS.jpg"
+    internalFolderName: "HOTDS"
+    dataFolderName: "dyingsun_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "283160"
+    settingsIdentifier: "HOTDS"
+    packageIndex: "https://thunderstore.io/c/hotds/api/v1/package-listing-index/"
+    steamFolderName: "DyingSun"
+    exeNames:
+      - "dyingsun.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "hotds"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/human-fall-flat.yml
+++ b/games/data/generated/human-fall-flat.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "477160"
 r2modman:
-  internalFolderName: "HumanFallFlat"
-  dataFolderName: "Human_Data"
-  settingsIdentifier: "HumanFallFlat"
-  packageIndex: "https://thunderstore.io/c/human-fall-flat/api/v1/package-listing-index/"
-  steamFolderName: "Human Fall Flat"
-  exeNames:
-    - "Human.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "hff"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Human Fall Flat"
+      iconUrl: "HumanFallFlat.png"
+    internalFolderName: "HumanFallFlat"
+    dataFolderName: "Human_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "477160"
+    settingsIdentifier: "HumanFallFlat"
+    packageIndex: "https://thunderstore.io/c/human-fall-flat/api/v1/package-listing-index/"
+    steamFolderName: "Human Fall Flat"
+    exeNames:
+      - "Human.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "hff"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/i-am-your-beast.yml
+++ b/games/data/generated/i-am-your-beast.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1876590"
 r2modman:
-  internalFolderName: "IAmYourBeast"
-  dataFolderName: "I Am Your Beast_Data"
-  settingsIdentifier: "I Am Your Beast"
-  packageIndex: "https://thunderstore.io/c/i-am-your-beast/api/v1/package-listing-index/"
-  steamFolderName: "I Am Your Beast"
-  exeNames:
-    - "I Am Your Beast.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "iayb"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "I Am Your Beast"
+      iconUrl: "IAmYourBeast.webp"
+    internalFolderName: "IAmYourBeast"
+    dataFolderName: "I Am Your Beast_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1876590"
+    settingsIdentifier: "I Am Your Beast"
+    packageIndex: "https://thunderstore.io/c/i-am-your-beast/api/v1/package-listing-index/"
+    steamFolderName: "I Am Your Beast"
+    exeNames:
+      - "I Am Your Beast.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "iayb"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/inscryption.yml
+++ b/games/data/generated/inscryption.yml
@@ -9,43 +9,51 @@ distributions:
   - platform: "other"
     identifier: null
 r2modman:
-  internalFolderName: "Inscryption"
-  dataFolderName: "Inscryption_Data"
-  settingsIdentifier: "Inscryption"
-  packageIndex: "https://thunderstore.io/c/inscryption/api/v1/package-listing-index/"
-  steamFolderName: "Inscryption"
-  exeNames:
-    - "Inscryption.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Inscryption"
+      iconUrl: "Inscryption.png"
+    internalFolderName: "Inscryption"
+    dataFolderName: "Inscryption_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1092790"
+      - platform: "other"
+        identifier: null
+    settingsIdentifier: "Inscryption"
+    packageIndex: "https://thunderstore.io/c/inscryption/api/v1/package-listing-index/"
+    steamFolderName: "Inscryption"
+    exeNames:
+      - "Inscryption.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/last-train-outta-wormtown.yml
+++ b/games/data/generated/last-train-outta-wormtown.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2318480"
 r2modman:
-  internalFolderName: "LastTrainOuttaWormtown"
-  dataFolderName: "Last Train Out Of WormTown_Data"
-  settingsIdentifier: "LastTrainOuttaWormtown"
-  packageIndex: "https://thunderstore.io/c/last-train-outta-wormtown/api/v1/package-listing-index/"
-  steamFolderName: "Last Train Outta' Wormtown"
-  exeNames:
-    - "Last Train Out Of WormTown.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "ltow"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Last Train Outta' Wormtown"
+      iconUrl: "LastTrainOuttaWormtown.png"
+    internalFolderName: "LastTrainOuttaWormtown"
+    dataFolderName: "Last Train Out Of WormTown_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2318480"
+    settingsIdentifier: "LastTrainOuttaWormtown"
+    packageIndex: "https://thunderstore.io/c/last-train-outta-wormtown/api/v1/package-listing-index/"
+    steamFolderName: "Last Train Outta' Wormtown"
+    exeNames:
+      - "Last Train Out Of WormTown.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "ltow"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/lethal-company.yml
+++ b/games/data/generated/lethal-company.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1966720"
 r2modman:
-  internalFolderName: "LethalCompany"
-  dataFolderName: "Lethal Company_Data"
-  settingsIdentifier: "LethalCompany"
-  packageIndex: "https://thunderstore.io/c/lethal-company/api/v1/package-listing-index/"
-  steamFolderName: "Lethal Company"
-  exeNames:
-    - "Lethal Company.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "lc"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Lethal Company"
+      iconUrl: "LethalCompany.png"
+    internalFolderName: "LethalCompany"
+    dataFolderName: "Lethal Company_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1966720"
+    settingsIdentifier: "LethalCompany"
+    packageIndex: "https://thunderstore.io/c/lethal-company/api/v1/package-listing-index/"
+    steamFolderName: "Lethal Company"
+    exeNames:
+      - "Lethal Company.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "lc"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/lethal-league-blaze.yml
+++ b/games/data/generated/lethal-league-blaze.yml
@@ -7,47 +7,53 @@ distributions:
   - platform: "steam"
     identifier: "553310"
 r2modman:
-  internalFolderName: "LethalLeagueBlaze"
-  dataFolderName: "LLBlaze_Data"
-  settingsIdentifier: "LethalLeagueBlaze"
-  packageIndex: "https://thunderstore.io/c/lethal-league-blaze/api/v1/package-listing-index/"
-  steamFolderName: "LLBlaze"
-  exeNames:
-    - "LLBlaze.exe"
-    - "LLBlaze.x86_64"
-    - "LLBlaze.x86"
-    - "LLBlaze.app"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "LLB"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Lethal League Blaze"
+      iconUrl: "LethalLeagueBlaze.png"
+    internalFolderName: "LethalLeagueBlaze"
+    dataFolderName: "LLBlaze_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "553310"
+    settingsIdentifier: "LethalLeagueBlaze"
+    packageIndex: "https://thunderstore.io/c/lethal-league-blaze/api/v1/package-listing-index/"
+    steamFolderName: "LLBlaze"
+    exeNames:
+      - "LLBlaze.exe"
+      - "LLBlaze.x86_64"
+      - "LLBlaze.x86"
+      - "LLBlaze.app"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "LLB"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/lost-skies.yml
+++ b/games/data/generated/lost-skies.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1931180"
 r2modman:
-  internalFolderName: "LostSkies"
-  dataFolderName: "LostSkies_Data"
-  settingsIdentifier: "LostSkies"
-  packageIndex: "https://thunderstore.io/c/lost-skies/api/v1/package-listing-index/"
-  steamFolderName: "LostSkies"
-  exeNames:
-    - "LostSkies.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "ls"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Lost Skies"
+      iconUrl: "LostSkies.png"
+    internalFolderName: "LostSkies"
+    dataFolderName: "LostSkies_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1931180"
+    settingsIdentifier: "LostSkies"
+    packageIndex: "https://thunderstore.io/c/lost-skies/api/v1/package-listing-index/"
+    steamFolderName: "LostSkies"
+    exeNames:
+      - "LostSkies.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "ls"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/lycans.yml
+++ b/games/data/generated/lycans.yml
@@ -7,43 +7,49 @@ distributions:
   - platform: "steam"
     identifier: "2596100"
 r2modman:
-  internalFolderName: "Lycans"
-  dataFolderName: "Lycans_Data"
-  settingsIdentifier: "Lycans"
-  packageIndex: "https://thunderstore.io/c/lycans/api/v1/package-listing-index/"
-  steamFolderName: "Lycans"
-  exeNames:
-    - "Lycans.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Lycans"
+      iconUrl: "Lycans.png"
+    internalFolderName: "Lycans"
+    dataFolderName: "Lycans_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2596100"
+    settingsIdentifier: "Lycans"
+    packageIndex: "https://thunderstore.io/c/lycans/api/v1/package-listing-index/"
+    steamFolderName: "Lycans"
+    exeNames:
+      - "Lycans.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/magicite.yml
+++ b/games/data/generated/magicite.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "268750"
 r2modman:
-  internalFolderName: "Magicite"
-  dataFolderName: "Magicite_Data"
-  settingsIdentifier: "Magicite"
-  packageIndex: "https://thunderstore.io/c/magicite/api/v1/package-listing-index/"
-  steamFolderName: "Magicite"
-  exeNames:
-    - "Magicite.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Magicite"
+      iconUrl: "Magicite.png"
+    internalFolderName: "Magicite"
+    dataFolderName: "Magicite_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "268750"
+    settingsIdentifier: "Magicite"
+    packageIndex: "https://thunderstore.io/c/magicite/api/v1/package-listing-index/"
+    steamFolderName: "Magicite"
+    exeNames:
+      - "Magicite.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/magicraft.yml
+++ b/games/data/generated/magicraft.yml
@@ -7,43 +7,49 @@ distributions:
   - platform: "steam"
     identifier: "2103140"
 r2modman:
-  internalFolderName: "Magicraft"
-  dataFolderName: "Magicraft_Data"
-  settingsIdentifier: "Magicraft"
-  packageIndex: "https://thunderstore.io/c/magicraft/api/v1/package-listing-index/"
-  steamFolderName: "Magicraft"
-  exeNames:
-    - "Magicraft.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Magicraft"
+      iconUrl: "Magicraft.png"
+    internalFolderName: "Magicraft"
+    dataFolderName: "Magicraft_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2103140"
+    settingsIdentifier: "Magicraft"
+    packageIndex: "https://thunderstore.io/c/magicraft/api/v1/package-listing-index/"
+    steamFolderName: "Magicraft"
+    exeNames:
+      - "Magicraft.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/mechanica.yml
+++ b/games/data/generated/mechanica.yml
@@ -7,43 +7,49 @@ distributions:
   - platform: "steam"
     identifier: "1226990"
 r2modman:
-  internalFolderName: "Mechanica"
-  dataFolderName: "Mechanica_Data"
-  settingsIdentifier: "Mechanica"
-  packageIndex: "https://thunderstore.io/c/mechanica/api/v1/package-listing-index/"
-  steamFolderName: "Mechanica"
-  exeNames:
-    - "Mechanica.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Mechanica"
+      iconUrl: "Mechanica.jpg"
+    internalFolderName: "Mechanica"
+    dataFolderName: "Mechanica_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1226990"
+    settingsIdentifier: "Mechanica"
+    packageIndex: "https://thunderstore.io/c/mechanica/api/v1/package-listing-index/"
+    steamFolderName: "Mechanica"
+    exeNames:
+      - "Mechanica.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/meeple-station.yml
+++ b/games/data/generated/meeple-station.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "900010"
 r2modman:
-  internalFolderName: "MeepleStation"
-  dataFolderName: "MeepleStation_Data"
-  settingsIdentifier: "MeepleStation"
-  packageIndex: "https://thunderstore.io/c/meeple-station/api/v1/package-listing-index/"
-  steamFolderName: "Meeple Station"
-  exeNames:
-    - "Meeple Station.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "ms"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Meeple Station"
+      iconUrl: "MeepleStation.png"
+    internalFolderName: "MeepleStation"
+    dataFolderName: "MeepleStation_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "900010"
+    settingsIdentifier: "MeepleStation"
+    packageIndex: "https://thunderstore.io/c/meeple-station/api/v1/package-listing-index/"
+    steamFolderName: "Meeple Station"
+    exeNames:
+      - "Meeple Station.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "ms"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/miside.yml
+++ b/games/data/generated/miside.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2527500"
 r2modman:
-  internalFolderName: "MiSide"
-  dataFolderName: "MiSideFull_Data"
-  settingsIdentifier: "MiSide"
-  packageIndex: "https://thunderstore.io/c/miside/api/v1/package-listing-index/"
-  steamFolderName: "MiSide"
-  exeNames:
-    - "MiSideFull.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "MiSide"
+      iconUrl: "MiSide.webp"
+    internalFolderName: "MiSide"
+    dataFolderName: "MiSideFull_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2527500"
+    settingsIdentifier: "MiSide"
+    packageIndex: "https://thunderstore.io/c/miside/api/v1/package-listing-index/"
+    steamFolderName: "MiSide"
+    exeNames:
+      - "MiSideFull.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/monster-train-2.yml
+++ b/games/data/generated/monster-train-2.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "3296150"
 r2modman:
-  internalFolderName: "MonsterTrain2"
-  dataFolderName: "MonsterTrain2-Demo_Data"
-  settingsIdentifier: "MonsterTrain2"
-  packageIndex: "https://thunderstore.io/c/monster-train-2/api/v1/package-listing-index/"
-  steamFolderName: "Monster Train 2 Demo"
-  exeNames:
-    - "MonsterTrain2-Demo.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "mt2"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Monster Train 2"
+      iconUrl: "MonsterTrain2.png"
+    internalFolderName: "MonsterTrain2"
+    dataFolderName: "MonsterTrain2-Demo_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "3296150"
+    settingsIdentifier: "MonsterTrain2"
+    packageIndex: "https://thunderstore.io/c/monster-train-2/api/v1/package-listing-index/"
+    steamFolderName: "Monster Train 2 Demo"
+    exeNames:
+      - "MonsterTrain2-Demo.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "mt2"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/muck.yml
+++ b/games/data/generated/muck.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1625450"
 r2modman:
-  internalFolderName: "Muck"
-  dataFolderName: "Muck_Data"
-  settingsIdentifier: "Muck"
-  packageIndex: "https://thunderstore.io/c/muck/api/v1/package-listing-index/"
-  steamFolderName: "Muck"
-  exeNames:
-    - "Muck.exe"
-    - "Muck.x86_64"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Muck"
+      iconUrl: "Muck.png"
+    internalFolderName: "Muck"
+    dataFolderName: "Muck_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1625450"
+    settingsIdentifier: "Muck"
+    packageIndex: "https://thunderstore.io/c/muck/api/v1/package-listing-index/"
+    steamFolderName: "Muck"
+    exeNames:
+      - "Muck.exe"
+      - "Muck.x86_64"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/my-dream-setup.yml
+++ b/games/data/generated/my-dream-setup.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2200780"
 r2modman:
-  internalFolderName: "MyDreamSetup"
-  dataFolderName: "MDS_Data"
-  settingsIdentifier: "MyDreamSetup"
-  packageIndex: "https://thunderstore.io/c/my-dream-setup/api/v1/package-listing-index/"
-  steamFolderName: "My dream setup/MDS"
-  exeNames:
-    - "MDS.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "MDS"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "My Dream Setup"
+      iconUrl: "MyDreamSetup.png"
+    internalFolderName: "MyDreamSetup"
+    dataFolderName: "MDS_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2200780"
+    settingsIdentifier: "MyDreamSetup"
+    packageIndex: "https://thunderstore.io/c/my-dream-setup/api/v1/package-listing-index/"
+    steamFolderName: "My dream setup/MDS"
+    exeNames:
+      - "MDS.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "MDS"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/nasb.yml
+++ b/games/data/generated/nasb.yml
@@ -7,67 +7,73 @@ distributions:
   - platform: "steam"
     identifier: "1414850"
 r2modman:
-  internalFolderName: "NASB"
-  dataFolderName: "Nickelodeon All-Star Brawl_Data"
-  settingsIdentifier: "NASB"
-  packageIndex: "https://thunderstore.io/c/nasb/api/v1/package-listing-index/"
-  steamFolderName: "Nickelodeon All-Star Brawl"
-  exeNames:
-    - "Nickelodeon All-Star Brawl.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "Nickelodeon All-Star Brawl"
-    - "NASB"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/CustomSongs"
-      defaultFileExtensions: []
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/Voicepacks"
-      defaultFileExtensions:
-        - ".voicepack"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/Skins"
-      defaultFileExtensions:
-        - ".nasbskin"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/Movesets"
-      defaultFileExtensions: []
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Nickelodeon All‑Star Brawl"
+      iconUrl: "NASB.jpg"
+    internalFolderName: "NASB"
+    dataFolderName: "Nickelodeon All-Star Brawl_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1414850"
+    settingsIdentifier: "NASB"
+    packageIndex: "https://thunderstore.io/c/nasb/api/v1/package-listing-index/"
+    steamFolderName: "Nickelodeon All-Star Brawl"
+    exeNames:
+      - "Nickelodeon All-Star Brawl.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "Nickelodeon All-Star Brawl"
+      - "NASB"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/CustomSongs"
+        defaultFileExtensions: []
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/Voicepacks"
+        defaultFileExtensions:
+          - ".voicepack"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/Skins"
+        defaultFileExtensions:
+          - ".nasbskin"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/Movesets"
+        defaultFileExtensions: []
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/nearly-dead.yml
+++ b/games/data/generated/nearly-dead.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1268900"
 r2modman:
-  internalFolderName: "NearlyDead"
-  dataFolderName: "Nearly Dead_Data"
-  settingsIdentifier: "NearlyDead"
-  packageIndex: "https://thunderstore.io/c/nearly-dead/api/v1/package-listing-index/"
-  steamFolderName: "Nearly Dead"
-  exeNames:
-    - "Nearly Dead.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "nd"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Nearly Dead"
+      iconUrl: "NearlyDead.png"
+    internalFolderName: "NearlyDead"
+    dataFolderName: "Nearly Dead_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1268900"
+    settingsIdentifier: "NearlyDead"
+    packageIndex: "https://thunderstore.io/c/nearly-dead/api/v1/package-listing-index/"
+    steamFolderName: "Nearly Dead"
+    exeNames:
+      - "Nearly Dead.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "nd"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/nine-sols.yml
+++ b/games/data/generated/nine-sols.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1809540"
 r2modman:
-  internalFolderName: "NineSols"
-  dataFolderName: "Nine Sols_Data"
-  settingsIdentifier: "NineSols"
-  packageIndex: "https://thunderstore.io/c/nine-sols/api/v1/package-listing-index/"
-  steamFolderName: "Nine Sols"
-  exeNames:
-    - "NineSols.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Nine Sols"
+      iconUrl: "NineSols.png"
+    internalFolderName: "NineSols"
+    dataFolderName: "Nine Sols_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1809540"
+    settingsIdentifier: "NineSols"
+    packageIndex: "https://thunderstore.io/c/nine-sols/api/v1/package-listing-index/"
+    steamFolderName: "Nine Sols"
+    exeNames:
+      - "NineSols.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/northstar.yml
+++ b/games/data/generated/northstar.yml
@@ -9,30 +9,38 @@ distributions:
   - platform: "origin"
     identifier: ""
 r2modman:
-  internalFolderName: "Titanfall2"
-  dataFolderName: ""
-  settingsIdentifier: "Titanfall2"
-  packageIndex: "https://thunderstore.io/c/northstar/api/v1/package-listing-index/"
-  steamFolderName: "Titanfall2"
-  exeNames:
-    - "NorthstarLauncher.exe"
-    - "Titanfall2.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "northstar"
-    - "ns"
-    - "tf2"
-    - "tf|2"
-  packageLoader: "northstar"
-  installRules:
-    - route: "R2Northstar/mods"
-      defaultFileExtensions: []
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions:
-    - "manifest.json"
-    - "README.md"
-    - "icon.png"
-    - "LICENCE"
+  - meta:
+      displayName: "Titanfall 2"
+      iconUrl: "Titanfall2.jpg"
+    internalFolderName: "Titanfall2"
+    dataFolderName: ""
+    distributions:
+      - platform: "steam-direct"
+        identifier: "1237970"
+      - platform: "origin"
+        identifier: ""
+    settingsIdentifier: "Titanfall2"
+    packageIndex: "https://thunderstore.io/c/northstar/api/v1/package-listing-index/"
+    steamFolderName: "Titanfall2"
+    exeNames:
+      - "NorthstarLauncher.exe"
+      - "Titanfall2.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "northstar"
+      - "ns"
+      - "tf2"
+      - "tf|2"
+    packageLoader: "northstar"
+    installRules:
+      - route: "R2Northstar/mods"
+        defaultFileExtensions: []
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions:
+      - "manifest.json"
+      - "README.md"
+      - "icon.png"
+      - "LICENCE"

--- a/games/data/generated/odd-remedy.yml
+++ b/games/data/generated/odd-remedy.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1745680"
 r2modman:
-  internalFolderName: "OddRemedy"
-  dataFolderName: "OddRemedy_Data"
-  settingsIdentifier: "OddRemedy"
-  packageIndex: "https://thunderstore.io/c/odd-remedy/api/v1/package-listing-index/"
-  steamFolderName: "OddRemedy"
-  exeNames:
-    - "OddRemedy.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "or"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Odd Remedy"
+      iconUrl: "OddRemedy.png"
+    internalFolderName: "OddRemedy"
+    dataFolderName: "OddRemedy_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1745680"
+    settingsIdentifier: "OddRemedy"
+    packageIndex: "https://thunderstore.io/c/odd-remedy/api/v1/package-listing-index/"
+    steamFolderName: "OddRemedy"
+    exeNames:
+      - "OddRemedy.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "or"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/old-market-simulator.yml
+++ b/games/data/generated/old-market-simulator.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2878420"
 r2modman:
-  internalFolderName: "OldMarketSimulator"
-  dataFolderName: "Old Market Simulator_Data"
-  settingsIdentifier: "Old Market Simulator"
-  packageIndex: "https://thunderstore.io/c/old-market-simulator/api/v1/package-listing-index/"
-  steamFolderName: "Old Market Simulator"
-  exeNames:
-    - "Old Market Simulator.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Old Market Simulator"
+      iconUrl: "OldMarketSimulator.png"
+    internalFolderName: "OldMarketSimulator"
+    dataFolderName: "Old Market Simulator_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2878420"
+    settingsIdentifier: "Old Market Simulator"
+    packageIndex: "https://thunderstore.io/c/old-market-simulator/api/v1/package-listing-index/"
+    steamFolderName: "Old Market Simulator"
+    exeNames:
+      - "Old Market Simulator.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/outward.yml
+++ b/games/data/generated/outward.yml
@@ -1,9 +1,15 @@
 uuid: "da7c4adc-dd04-4fca-b35c-31bcda26c53e"
 label: "outward"
 meta:
-  displayName: "Outward Definitive"
-  iconUrl: "OutwardDe.jpg"
+  displayName: "Outward"
+  iconUrl: "Outward.jpg"
 distributions:
+  - platform: "steam"
+    identifier: "794260"
+  - platform: "epic-games-store"
+    identifier: "Viola"
+  - platform: "other"
+    identifier: null
   - platform: "steam"
     identifier: "1758860"
   - platform: "epic-games-store"
@@ -11,43 +17,109 @@ distributions:
   - platform: "other"
     identifier: null
 r2modman:
-  internalFolderName: "OutwardDe"
-  dataFolderName: "Outward Definitive Edition_Data"
-  settingsIdentifier: "OutwardDe"
-  packageIndex: "https://thunderstore.io/c/outward/api/v1/package-listing-index/"
-  steamFolderName: "Outward/Outward_Defed"
-  exeNames:
-    - "Outward Definitive Edition.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Outward"
+      iconUrl: "Outward.jpg"
+    internalFolderName: "Outward"
+    dataFolderName: "Outward_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "794260"
+      - platform: "epic-games-store"
+        identifier: "Viola"
+      - platform: "other"
+        identifier: null
+      - platform: "steam"
+        identifier: "1758860"
+      - platform: "epic-games-store"
+        identifier: "f07a51af8ac845ea96f792fb485e04a3"
+      - platform: "other"
+        identifier: null
+    settingsIdentifier: "Outward"
+    packageIndex: "https://thunderstore.io/c/outward/api/v1/package-listing-index/"
+    steamFolderName: "Outward"
+    exeNames:
+      - "Outward.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null
+  - meta:
+      displayName: "Outward Definitive"
+      iconUrl: "OutwardDe.jpg"
+    internalFolderName: "OutwardDe"
+    dataFolderName: "Outward Definitive Edition_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1758860"
+      - platform: "epic-games-store"
+        identifier: "f07a51af8ac845ea96f792fb485e04a3"
+      - platform: "other"
+        identifier: null
+    settingsIdentifier: "OutwardDe"
+    packageIndex: "https://thunderstore.io/c/outward/api/v1/package-listing-index/"
+    steamFolderName: "Outward/Outward_Defed"
+    exeNames:
+      - "Outward Definitive Edition.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/palworld.yml
+++ b/games/data/generated/palworld.yml
@@ -7,17 +7,23 @@ distributions:
   - platform: "steam"
     identifier: "1623730"
 r2modman:
-  internalFolderName: "Palworld"
-  dataFolderName: "Pal"
-  settingsIdentifier: "Palworld"
-  packageIndex: "https://thunderstore.io/c/palworld/api/v1/package-listing-index/"
-  steamFolderName: "Palworld"
-  exeNames:
-    - "Palworld.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "palworld"
-  packageLoader: "shimloader"
-  installRules: []
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Palworld"
+      iconUrl: "Palworld.png"
+    internalFolderName: "Palworld"
+    dataFolderName: "Pal"
+    distributions:
+      - platform: "steam"
+        identifier: "1623730"
+    settingsIdentifier: "Palworld"
+    packageIndex: "https://thunderstore.io/c/palworld/api/v1/package-listing-index/"
+    steamFolderName: "Palworld"
+    exeNames:
+      - "Palworld.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "palworld"
+    packageLoader: "shimloader"
+    installRules: []
+    relativeFileExclusions: null

--- a/games/data/generated/panicore.yml
+++ b/games/data/generated/panicore.yml
@@ -7,17 +7,23 @@ distributions:
   - platform: "steam"
     identifier: "2695940"
 r2modman:
-  internalFolderName: "Panicore"
-  dataFolderName: "Panicore"
-  settingsIdentifier: "Panicore"
-  packageIndex: "https://thunderstore.io/c/panicore/api/v1/package-listing-index/"
-  steamFolderName: "Panicore"
-  exeNames:
-    - "Panicore.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "panicore"
-  packageLoader: "shimloader"
-  installRules: []
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Panicore"
+      iconUrl: "Panicore.png"
+    internalFolderName: "Panicore"
+    dataFolderName: "Panicore"
+    distributions:
+      - platform: "steam"
+        identifier: "2695940"
+    settingsIdentifier: "Panicore"
+    packageIndex: "https://thunderstore.io/c/panicore/api/v1/package-listing-index/"
+    steamFolderName: "Panicore"
+    exeNames:
+      - "Panicore.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "panicore"
+    packageLoader: "shimloader"
+    installRules: []
+    relativeFileExclusions: null

--- a/games/data/generated/paquerette-down-the-bunburrows.yml
+++ b/games/data/generated/paquerette-down-the-bunburrows.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1628610"
 r2modman:
-  internalFolderName: "PaqueretteDownTheBunburrows"
-  dataFolderName: "Paquerette Down the Bunburrows_Data"
-  settingsIdentifier: "PaqueretteDownTheBunburrows"
-  packageIndex: "https://thunderstore.io/c/paquerette-down-the-bunburrows/api/v1/package-listing-index/"
-  steamFolderName: "Paquerette Down the Bunburrows"
-  exeNames:
-    - "Paquerette Down the Bunburrows.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Paquerette Down the Bunburrows"
+      iconUrl: "PaqueretteDownTheBunburrows.png"
+    internalFolderName: "PaqueretteDownTheBunburrows"
+    dataFolderName: "Paquerette Down the Bunburrows_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1628610"
+    settingsIdentifier: "PaqueretteDownTheBunburrows"
+    packageIndex: "https://thunderstore.io/c/paquerette-down-the-bunburrows/api/v1/package-listing-index/"
+    steamFolderName: "Paquerette Down the Bunburrows"
+    exeNames:
+      - "Paquerette Down the Bunburrows.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/patch-quest.yml
+++ b/games/data/generated/patch-quest.yml
@@ -7,54 +7,60 @@ distributions:
   - platform: "steam"
     identifier: "1347970"
 r2modman:
-  internalFolderName: "PatchQuest"
-  dataFolderName: "PatchQuest_Data"
-  settingsIdentifier: "PatchQuest"
-  packageIndex: "https://thunderstore.io/c/patch-quest/api/v1/package-listing-index/"
-  steamFolderName: "Patch Quest"
-  exeNames:
-    - "Patch Quest.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "pq"
-  packageLoader: "melonloader"
-  installRules:
-    - route: "Mods"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "UserData/ModManager"
-      defaultFileExtensions: []
-      trackingMethod: "subdir-no-flatten"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "UserLibs"
-      defaultFileExtensions:
-        - ".lib.dll"
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "MelonLoader"
-      defaultFileExtensions: []
-      trackingMethod: "state"
-      subRoutes:
-        - route: "Managed"
-          defaultFileExtensions:
-            - ".managed.dll"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "Libs"
-          defaultFileExtensions: []
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-      isDefaultLocation: false
-  relativeFileExclusions:
-    - "manifest.json"
-    - "icon.png"
-    - "README.md"
-    - "LICENCE"
+  - meta:
+      displayName: "Patch Quest"
+      iconUrl: "patch-quest.jpg"
+    internalFolderName: "PatchQuest"
+    dataFolderName: "PatchQuest_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1347970"
+    settingsIdentifier: "PatchQuest"
+    packageIndex: "https://thunderstore.io/c/patch-quest/api/v1/package-listing-index/"
+    steamFolderName: "Patch Quest"
+    exeNames:
+      - "Patch Quest.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "pq"
+    packageLoader: "melonloader"
+    installRules:
+      - route: "Mods"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "UserData/ModManager"
+        defaultFileExtensions: []
+        trackingMethod: "subdir-no-flatten"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "UserLibs"
+        defaultFileExtensions:
+          - ".lib.dll"
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "MelonLoader"
+        defaultFileExtensions: []
+        trackingMethod: "state"
+        subRoutes:
+          - route: "Managed"
+            defaultFileExtensions:
+              - ".managed.dll"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "Libs"
+            defaultFileExtensions: []
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+        isDefaultLocation: false
+    relativeFileExclusions:
+      - "manifest.json"
+      - "icon.png"
+      - "README.md"
+      - "LICENCE"

--- a/games/data/generated/peaks-of-yore.yml
+++ b/games/data/generated/peaks-of-yore.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2236070"
 r2modman:
-  internalFolderName: "PeaksOfYore"
-  dataFolderName: "Peaks of Yore_Data"
-  settingsIdentifier: "Peaks of Yore"
-  packageIndex: "https://thunderstore.io/c/peaks-of-yore/api/v1/package-listing-index/"
-  steamFolderName: "Peaks of Yore"
-  exeNames:
-    - "Peaks of Yore.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "poy"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Peaks of Yore"
+      iconUrl: "PeaksOfYore.png"
+    internalFolderName: "PeaksOfYore"
+    dataFolderName: "Peaks of Yore_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2236070"
+    settingsIdentifier: "Peaks of Yore"
+    packageIndex: "https://thunderstore.io/c/peaks-of-yore/api/v1/package-listing-index/"
+    steamFolderName: "Peaks of Yore"
+    exeNames:
+      - "Peaks of Yore.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "poy"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/peglin.yml
+++ b/games/data/generated/peglin.yml
@@ -9,43 +9,51 @@ distributions:
   - platform: "other"
     identifier: null
 r2modman:
-  internalFolderName: "Peglin"
-  dataFolderName: "Peglin_Data"
-  settingsIdentifier: "Peglin"
-  packageIndex: "https://thunderstore.io/c/peglin/api/v1/package-listing-index/"
-  steamFolderName: "Peglin"
-  exeNames:
-    - "Peglin.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Peglin"
+      iconUrl: "Peglin.jpg"
+    internalFolderName: "Peglin"
+    dataFolderName: "Peglin_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1296610"
+      - platform: "other"
+        identifier: null
+    settingsIdentifier: "Peglin"
+    packageIndex: "https://thunderstore.io/c/peglin/api/v1/package-listing-index/"
+    steamFolderName: "Peglin"
+    exeNames:
+      - "Peglin.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/plasma.yml
+++ b/games/data/generated/plasma.yml
@@ -7,43 +7,49 @@ distributions:
   - platform: "steam"
     identifier: "1409160"
 r2modman:
-  internalFolderName: "Plasma"
-  dataFolderName: "Plasma_Data"
-  settingsIdentifier: "Plasma"
-  packageIndex: "https://thunderstore.io/c/plasma/api/v1/package-listing-index/"
-  steamFolderName: "Plasma"
-  exeNames:
-    - "Plasma.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Plasma"
+      iconUrl: "Plasma.jpg"
+    internalFolderName: "Plasma"
+    dataFolderName: "Plasma_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1409160"
+    settingsIdentifier: "Plasma"
+    packageIndex: "https://thunderstore.io/c/plasma/api/v1/package-listing-index/"
+    steamFolderName: "Plasma"
+    exeNames:
+      - "Plasma.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/potion-craft.yml
+++ b/games/data/generated/potion-craft.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1210320"
 r2modman:
-  internalFolderName: "PotionCraft"
-  dataFolderName: "Potion Craft_Data"
-  settingsIdentifier: "PotionCraft"
-  packageIndex: "https://thunderstore.io/c/potion-craft/api/v1/package-listing-index/"
-  steamFolderName: "Potion Craft"
-  exeNames:
-    - "Potion Craft.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "pc"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Potion Craft"
+      iconUrl: "PotionCraft.jpg"
+    internalFolderName: "PotionCraft"
+    dataFolderName: "Potion Craft_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1210320"
+    settingsIdentifier: "PotionCraft"
+    packageIndex: "https://thunderstore.io/c/potion-craft/api/v1/package-listing-index/"
+    steamFolderName: "Potion Craft"
+    exeNames:
+      - "Potion Craft.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "pc"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/pulsar-lost-colony.yml
+++ b/games/data/generated/pulsar-lost-colony.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "252870"
 r2modman:
-  internalFolderName: "PulsarLostColony"
-  dataFolderName: "PULSAR_LostColony_Data"
-  settingsIdentifier: "PulsarLostColony"
-  packageIndex: "https://thunderstore.io/c/pulsar-lost-colony/api/v1/package-listing-index/"
-  steamFolderName: "PULSARLostColony"
-  exeNames:
-    - "PULSAR_LostColony.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "plc"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Pulsar: Lost Colony"
+      iconUrl: "PulsarLostColony.png"
+    internalFolderName: "PulsarLostColony"
+    dataFolderName: "PULSAR_LostColony_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "252870"
+    settingsIdentifier: "PulsarLostColony"
+    packageIndex: "https://thunderstore.io/c/pulsar-lost-colony/api/v1/package-listing-index/"
+    steamFolderName: "PULSARLostColony"
+    exeNames:
+      - "PULSAR_LostColony.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "plc"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/ravenfield.yml
+++ b/games/data/generated/ravenfield.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "636480"
 r2modman:
-  internalFolderName: "Ravenfield"
-  dataFolderName: "ravenfield_Data"
-  settingsIdentifier: "Ravenfield"
-  packageIndex: "https://thunderstore.io/c/ravenfield/api/v1/package-listing-index/"
-  steamFolderName: "Ravenfield"
-  exeNames:
-    - "ravenfield.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "rf"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Ravenfield"
+      iconUrl: "Ravenfield.jpg"
+    internalFolderName: "Ravenfield"
+    dataFolderName: "ravenfield_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "636480"
+    settingsIdentifier: "Ravenfield"
+    packageIndex: "https://thunderstore.io/c/ravenfield/api/v1/package-listing-index/"
+    steamFolderName: "Ravenfield"
+    exeNames:
+      - "ravenfield.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "rf"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/receiver-2.yml
+++ b/games/data/generated/receiver-2.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1129310"
 r2modman:
-  internalFolderName: "Receiver2"
-  dataFolderName: "Receiver2_Data"
-  settingsIdentifier: "Receiver2"
-  packageIndex: "https://thunderstore.io/c/receiver-2/api/v1/package-listing-index/"
-  steamFolderName: "Receiver 2"
-  exeNames:
-    - "Receiver2.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "rec2"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Receiver 2"
+      iconUrl: "receiver-2.jpg"
+    internalFolderName: "Receiver2"
+    dataFolderName: "Receiver2_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1129310"
+    settingsIdentifier: "Receiver2"
+    packageIndex: "https://thunderstore.io/c/receiver-2/api/v1/package-listing-index/"
+    steamFolderName: "Receiver 2"
+    exeNames:
+      - "Receiver2.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "rec2"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/repo.yml
+++ b/games/data/generated/repo.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "3241660"
 r2modman:
-  internalFolderName: "REPO"
-  dataFolderName: "REPO_Data"
-  settingsIdentifier: "REPO"
-  packageIndex: "https://thunderstore.io/c/repo/api/v1/package-listing-index/"
-  steamFolderName: "REPO"
-  exeNames:
-    - "REPO.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "repo"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "R.E.P.O."
+      iconUrl: "REPO.png"
+    internalFolderName: "REPO"
+    dataFolderName: "REPO_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "3241660"
+    settingsIdentifier: "REPO"
+    packageIndex: "https://thunderstore.io/c/repo/api/v1/package-listing-index/"
+    steamFolderName: "REPO"
+    exeNames:
+      - "REPO.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "repo"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/risk-of-rain-returns.yml
+++ b/games/data/generated/risk-of-rain-returns.yml
@@ -7,17 +7,23 @@ distributions:
   - platform: "steam"
     identifier: "1337520"
 r2modman:
-  internalFolderName: "RiskofRainReturns"
-  dataFolderName: ""
-  settingsIdentifier: "RiskofRainReturns"
-  packageIndex: "https://thunderstore.io/c/risk-of-rain-returns/api/v1/package-listing-index/"
-  steamFolderName: "Risk of Rain Returns"
-  exeNames:
-    - "Risk of Rain Returns.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "rorr"
-  packageLoader: "returnofmodding"
-  installRules: []
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Risk of Rain Returns"
+      iconUrl: "RiskOfRainReturns.png"
+    internalFolderName: "RiskofRainReturns"
+    dataFolderName: ""
+    distributions:
+      - platform: "steam"
+        identifier: "1337520"
+    settingsIdentifier: "RiskofRainReturns"
+    packageIndex: "https://thunderstore.io/c/risk-of-rain-returns/api/v1/package-listing-index/"
+    steamFolderName: "Risk of Rain Returns"
+    exeNames:
+      - "Risk of Rain Returns.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "rorr"
+    packageLoader: "returnofmodding"
+    installRules: []
+    relativeFileExclusions: null

--- a/games/data/generated/riskofrain2.yml
+++ b/games/data/generated/riskofrain2.yml
@@ -8,45 +8,104 @@ distributions:
     identifier: "632360"
   - platform: "epic-games-store"
     identifier: "4b3dcc5723454a47a9112d8fe8fd5f5c"
+  - platform: "steam"
+    identifier: "1180760"
 r2modman:
-  internalFolderName: "RiskOfRain2"
-  dataFolderName: "Risk of Rain 2_Data"
-  settingsIdentifier: "RiskOfRain2"
-  packageIndex: "https://thunderstore.io/c/riskofrain2/api/v1/package-listing-index/"
-  steamFolderName: "Risk of Rain 2"
-  exeNames:
-    - "Risk of Rain 2.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "ROR2"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Risk of Rain 2"
+      iconUrl: "RiskOfRain2.jpg"
+    internalFolderName: "RiskOfRain2"
+    dataFolderName: "Risk of Rain 2_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "632360"
+      - platform: "epic-games-store"
+        identifier: "4b3dcc5723454a47a9112d8fe8fd5f5c"
+      - platform: "steam"
+        identifier: "1180760"
+    settingsIdentifier: "RiskOfRain2"
+    packageIndex: "https://thunderstore.io/c/riskofrain2/api/v1/package-listing-index/"
+    steamFolderName: "Risk of Rain 2"
+    exeNames:
+      - "Risk of Rain 2.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "ROR2"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null
+  - meta:
+      displayName: "Risk of Rain 2 Dedicated Server"
+      iconUrl: "RiskOfRain2.jpg"
+    internalFolderName: "RiskOfRain2"
+    dataFolderName: "Risk of Rain 2_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1180760"
+    settingsIdentifier: "RiskOfRain2Server"
+    packageIndex: "https://thunderstore.io/c/riskofrain2/api/v1/package-listing-index/"
+    steamFolderName: "Risk of Rain 2 Dedicated Server"
+    exeNames:
+      - "Risk of Rain 2.exe"
+    gameInstanceType: "server"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "ROR2"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/rogue-genesia.yml
+++ b/games/data/generated/rogue-genesia.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2067920"
 r2modman:
-  internalFolderName: "RogueGenesia"
-  dataFolderName: "Rogue Genesia_Data"
-  settingsIdentifier: "RogueGenesia"
-  packageIndex: "https://thunderstore.io/c/rogue-genesia/api/v1/package-listing-index/"
-  steamFolderName: "Rogue Genesia"
-  exeNames:
-    - "Rogue Genesia.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "rg"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Rogue : Genesia"
+      iconUrl: "RogueGenesia.jpg"
+    internalFolderName: "RogueGenesia"
+    dataFolderName: "Rogue Genesia_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2067920"
+    settingsIdentifier: "RogueGenesia"
+    packageIndex: "https://thunderstore.io/c/rogue-genesia/api/v1/package-listing-index/"
+    steamFolderName: "Rogue Genesia"
+    exeNames:
+      - "Rogue Genesia.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "rg"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/rogue-tower.yml
+++ b/games/data/generated/rogue-tower.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1843760"
 r2modman:
-  internalFolderName: "RogueTower"
-  dataFolderName: "Rogue Tower_Data"
-  settingsIdentifier: "RogueTower"
-  packageIndex: "https://thunderstore.io/c/rogue-tower/api/v1/package-listing-index/"
-  steamFolderName: "Rogue Tower"
-  exeNames:
-    - "Rogue Tower.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "rt"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Rogue Tower"
+      iconUrl: "RogueTower.jpg"
+    internalFolderName: "RogueTower"
+    dataFolderName: "Rogue Tower_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1843760"
+    settingsIdentifier: "RogueTower"
+    packageIndex: "https://thunderstore.io/c/rogue-tower/api/v1/package-listing-index/"
+    steamFolderName: "Rogue Tower"
+    exeNames:
+      - "Rogue Tower.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "rt"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/rounds.yml
+++ b/games/data/generated/rounds.yml
@@ -7,43 +7,49 @@ distributions:
   - platform: "steam"
     identifier: "1557740"
 r2modman:
-  internalFolderName: "ROUNDS"
-  dataFolderName: "Rounds_Data"
-  settingsIdentifier: "ROUNDS"
-  packageIndex: "https://thunderstore.io/c/rounds/api/v1/package-listing-index/"
-  steamFolderName: "ROUNDS"
-  exeNames:
-    - "Rounds.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "ROUNDS"
+      iconUrl: "ROUNDS.png"
+    internalFolderName: "ROUNDS"
+    dataFolderName: "Rounds_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1557740"
+    settingsIdentifier: "ROUNDS"
+    packageIndex: "https://thunderstore.io/c/rounds/api/v1/package-listing-index/"
+    steamFolderName: "ROUNDS"
+    exeNames:
+      - "Rounds.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/rumble.yml
+++ b/games/data/generated/rumble.yml
@@ -7,53 +7,59 @@ distributions:
   - platform: "steam"
     identifier: "890550"
 r2modman:
-  internalFolderName: "RUMBLE"
-  dataFolderName: "RUMBLE_Data"
-  settingsIdentifier: "RUMBLE"
-  packageIndex: "https://thunderstore.io/c/rumble/api/v1/package-listing-index/"
-  steamFolderName: "RUMBLE"
-  exeNames:
-    - "RUMBLE.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "melonloader"
-  installRules:
-    - route: "Mods"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "UserData/ModManager"
-      defaultFileExtensions: []
-      trackingMethod: "subdir-no-flatten"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "UserLibs"
-      defaultFileExtensions:
-        - ".lib.dll"
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "MelonLoader"
-      defaultFileExtensions: []
-      trackingMethod: "state"
-      subRoutes:
-        - route: "Managed"
-          defaultFileExtensions:
-            - ".managed.dll"
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-        - route: "Libs"
-          defaultFileExtensions: []
-          trackingMethod: "state"
-          subRoutes: []
-          isDefaultLocation: false
-      isDefaultLocation: false
-  relativeFileExclusions:
-    - "manifest.json"
-    - "icon.png"
-    - "README.md"
-    - "LICENCE"
+  - meta:
+      displayName: "RUMBLE"
+      iconUrl: "RUMBLE.png"
+    internalFolderName: "RUMBLE"
+    dataFolderName: "RUMBLE_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "890550"
+    settingsIdentifier: "RUMBLE"
+    packageIndex: "https://thunderstore.io/c/rumble/api/v1/package-listing-index/"
+    steamFolderName: "RUMBLE"
+    exeNames:
+      - "RUMBLE.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "melonloader"
+    installRules:
+      - route: "Mods"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "UserData/ModManager"
+        defaultFileExtensions: []
+        trackingMethod: "subdir-no-flatten"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "UserLibs"
+        defaultFileExtensions:
+          - ".lib.dll"
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "MelonLoader"
+        defaultFileExtensions: []
+        trackingMethod: "state"
+        subRoutes:
+          - route: "Managed"
+            defaultFileExtensions:
+              - ".managed.dll"
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+          - route: "Libs"
+            defaultFileExtensions: []
+            trackingMethod: "state"
+            subRoutes: []
+            isDefaultLocation: false
+        isDefaultLocation: false
+    relativeFileExclusions:
+      - "manifest.json"
+      - "icon.png"
+      - "README.md"
+      - "LICENCE"

--- a/games/data/generated/sailwind.yml
+++ b/games/data/generated/sailwind.yml
@@ -7,43 +7,49 @@ distributions:
   - platform: "steam"
     identifier: "1764530"
 r2modman:
-  internalFolderName: "Sailwind"
-  dataFolderName: "Sailwind_Data"
-  settingsIdentifier: "Sailwind"
-  packageIndex: "https://thunderstore.io/c/sailwind/api/v1/package-listing-index/"
-  steamFolderName: "Sailwind"
-  exeNames:
-    - "Sailwind.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Sailwind"
+      iconUrl: "Sailwind.png"
+    internalFolderName: "Sailwind"
+    dataFolderName: "Sailwind_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1764530"
+    settingsIdentifier: "Sailwind"
+    packageIndex: "https://thunderstore.io/c/sailwind/api/v1/package-listing-index/"
+    steamFolderName: "Sailwind"
+    exeNames:
+      - "Sailwind.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/schedule-i.yml
+++ b/games/data/generated/schedule-i.yml
@@ -7,17 +7,23 @@ distributions:
   - platform: "steam"
     identifier: "3164500"
 r2modman:
-  internalFolderName: "ScheduleI"
-  dataFolderName: "Schedule I_Data"
-  settingsIdentifier: "ScheduleI"
-  packageIndex: "https://thunderstore.io/c/schedule-i/api/v1/package-listing-index/"
-  steamFolderName: "Schedule I"
-  exeNames:
-    - "Schedule I.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "recursive-melonloader"
-  installRules: []
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Schedule I"
+      iconUrl: "ScheduleI.png"
+    internalFolderName: "ScheduleI"
+    dataFolderName: "Schedule I_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "3164500"
+    settingsIdentifier: "ScheduleI"
+    packageIndex: "https://thunderstore.io/c/schedule-i/api/v1/package-listing-index/"
+    steamFolderName: "Schedule I"
+    exeNames:
+      - "Schedule I.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "recursive-melonloader"
+    installRules: []
+    relativeFileExclusions: null

--- a/games/data/generated/screw-drivers.yml
+++ b/games/data/generated/screw-drivers.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1279510"
 r2modman:
-  internalFolderName: "ScrewDrivers"
-  dataFolderName: "Screw Drivers_Data"
-  settingsIdentifier: "ScrewDrivers"
-  packageIndex: "https://thunderstore.io/c/screw-drivers/api/v1/package-listing-index/"
-  steamFolderName: "Screw Drivers"
-  exeNames:
-    - "Screw Drivers.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Screw Drivers"
+      iconUrl: "ScrewDrivers.png"
+    internalFolderName: "ScrewDrivers"
+    dataFolderName: "Screw Drivers_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1279510"
+    settingsIdentifier: "ScrewDrivers"
+    packageIndex: "https://thunderstore.io/c/screw-drivers/api/v1/package-listing-index/"
+    steamFolderName: "Screw Drivers"
+    exeNames:
+      - "Screw Drivers.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/shadows-of-doubt.yml
+++ b/games/data/generated/shadows-of-doubt.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "986130"
 r2modman:
-  internalFolderName: "ShadowsofDoubt"
-  dataFolderName: "ShadowsofDoubt_Data"
-  settingsIdentifier: "ShadowsofDoubt"
-  packageIndex: "https://thunderstore.io/c/shadows-of-doubt/api/v1/package-listing-index/"
-  steamFolderName: "Shadows of Doubt"
-  exeNames:
-    - "Shadows of Doubt.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "sod"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Shadows of Doubt"
+      iconUrl: "shadows-of-doubt.jpg"
+    internalFolderName: "ShadowsofDoubt"
+    dataFolderName: "ShadowsofDoubt_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "986130"
+    settingsIdentifier: "ShadowsofDoubt"
+    packageIndex: "https://thunderstore.io/c/shadows-of-doubt/api/v1/package-listing-index/"
+    steamFolderName: "Shadows of Doubt"
+    exeNames:
+      - "Shadows of Doubt.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "sod"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/shadows-over-loathing.yml
+++ b/games/data/generated/shadows-over-loathing.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1939160"
 r2modman:
-  internalFolderName: "ShadowsOverLoathing"
-  dataFolderName: "ShadowsOverLoathing_Data"
-  settingsIdentifier: "ShadowsOverLoathing"
-  packageIndex: "https://thunderstore.io/c/shadows-over-loathing/api/v1/package-listing-index/"
-  steamFolderName: "Shadows Over Loathing/Shadows Over Loathing"
-  exeNames:
-    - "Shadows Over Loathing.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "sol"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Shadows Over Loathing"
+      iconUrl: "shadows-over-loathing.jpg"
+    internalFolderName: "ShadowsOverLoathing"
+    dataFolderName: "ShadowsOverLoathing_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1939160"
+    settingsIdentifier: "ShadowsOverLoathing"
+    packageIndex: "https://thunderstore.io/c/shadows-over-loathing/api/v1/package-listing-index/"
+    steamFolderName: "Shadows Over Loathing/Shadows Over Loathing"
+    exeNames:
+      - "Shadows Over Loathing.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "sol"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/shapez-2.yml
+++ b/games/data/generated/shapez-2.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2162800"
 r2modman:
-  internalFolderName: "Shapez2"
-  dataFolderName: "shapez 2_Data"
-  settingsIdentifier: "Shapez2"
-  packageIndex: "https://thunderstore.io/c/shapez-2/api/v1/package-listing-index/"
-  steamFolderName: "shapez 2"
-  exeNames:
-    - "shapez 2.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Shapez 2"
+      iconUrl: "Shapez2.png"
+    internalFolderName: "Shapez2"
+    dataFolderName: "shapez 2_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2162800"
+    settingsIdentifier: "Shapez2"
+    packageIndex: "https://thunderstore.io/c/shapez-2/api/v1/package-listing-index/"
+    steamFolderName: "shapez 2"
+    exeNames:
+      - "shapez 2.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/skul-the-hero-slayer.yml
+++ b/games/data/generated/skul-the-hero-slayer.yml
@@ -7,43 +7,49 @@ distributions:
   - platform: "steam"
     identifier: "1147560"
 r2modman:
-  internalFolderName: "SkulTheHeroSlayer"
-  dataFolderName: "Skul_Data"
-  settingsIdentifier: "SkulTheHeroSlayer"
-  packageIndex: "https://thunderstore.io/c/skul-the-hero-slayer/api/v1/package-listing-index/"
-  steamFolderName: "Skul"
-  exeNames:
-    - "Skul.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Skul: The Hero Slayer"
+      iconUrl: "skul-the-hero-slayer.jpg"
+    internalFolderName: "SkulTheHeroSlayer"
+    dataFolderName: "Skul_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1147560"
+    settingsIdentifier: "SkulTheHeroSlayer"
+    packageIndex: "https://thunderstore.io/c/skul-the-hero-slayer/api/v1/package-listing-index/"
+    steamFolderName: "Skul"
+    exeNames:
+      - "Skul.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/slipstream-rogue-space.yml
+++ b/games/data/generated/slipstream-rogue-space.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2765860"
 r2modman:
-  internalFolderName: "SlipstreamRogueSpace"
-  dataFolderName: "Slipstream_Win_Data"
-  settingsIdentifier: "SlipstreamRogueSpace"
-  packageIndex: "https://thunderstore.io/c/slipstream-rogue-space/api/v1/package-listing-index/"
-  steamFolderName: "Slipstream Rogue Space"
-  exeNames:
-    - "Slipstream_Win.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "srs"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Slipstream: Rogue Space"
+      iconUrl: "SlipstreamRogueSpace.png"
+    internalFolderName: "SlipstreamRogueSpace"
+    dataFolderName: "Slipstream_Win_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2765860"
+    settingsIdentifier: "SlipstreamRogueSpace"
+    packageIndex: "https://thunderstore.io/c/slipstream-rogue-space/api/v1/package-listing-index/"
+    steamFolderName: "Slipstream Rogue Space"
+    exeNames:
+      - "Slipstream_Win.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "srs"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/songs-of-conquest.yml
+++ b/games/data/generated/songs-of-conquest.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "867210"
 r2modman:
-  internalFolderName: "SongsOfConquest"
-  dataFolderName: "SongsOfConquest_Data"
-  settingsIdentifier: "SongsOfConquest"
-  packageIndex: "https://thunderstore.io/c/songs-of-conquest/api/v1/package-listing-index/"
-  steamFolderName: "SongsOfConquest"
-  exeNames:
-    - "SongsOfConquest.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "soc"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Songs of Conquest"
+      iconUrl: "SongsOfConquest.png"
+    internalFolderName: "SongsOfConquest"
+    dataFolderName: "SongsOfConquest_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "867210"
+    settingsIdentifier: "SongsOfConquest"
+    packageIndex: "https://thunderstore.io/c/songs-of-conquest/api/v1/package-listing-index/"
+    steamFolderName: "SongsOfConquest"
+    exeNames:
+      - "SongsOfConquest.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "soc"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/sons-of-the-forest.yml
+++ b/games/data/generated/sons-of-the-forest.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1326470"
 r2modman:
-  internalFolderName: "SonsOfTheForest"
-  dataFolderName: "SonsOfTheForest_Data"
-  settingsIdentifier: "SonsOfTheForest"
-  packageIndex: "https://thunderstore.io/c/sons-of-the-forest/api/v1/package-listing-index/"
-  steamFolderName: "Sons Of The Forest"
-  exeNames:
-    - "SonsOfTheForest.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "sotf"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Sons Of The Forest"
+      iconUrl: "sons-of-the-forest.jpg"
+    internalFolderName: "SonsOfTheForest"
+    dataFolderName: "SonsOfTheForest_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1326470"
+    settingsIdentifier: "SonsOfTheForest"
+    packageIndex: "https://thunderstore.io/c/sons-of-the-forest/api/v1/package-listing-index/"
+    steamFolderName: "Sons Of The Forest"
+    exeNames:
+      - "SonsOfTheForest.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "sotf"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/stacklands.yml
+++ b/games/data/generated/stacklands.yml
@@ -7,43 +7,49 @@ distributions:
   - platform: "steam"
     identifier: "1948280"
 r2modman:
-  internalFolderName: "Stacklands"
-  dataFolderName: "Stacklands_Data"
-  settingsIdentifier: "Stacklands"
-  packageIndex: "https://thunderstore.io/c/stacklands/api/v1/package-listing-index/"
-  steamFolderName: "Stacklands"
-  exeNames:
-    - "Stacklands.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Stacklands"
+      iconUrl: "Stacklands.jpg"
+    internalFolderName: "Stacklands"
+    dataFolderName: "Stacklands_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1948280"
+    settingsIdentifier: "Stacklands"
+    packageIndex: "https://thunderstore.io/c/stacklands/api/v1/package-listing-index/"
+    steamFolderName: "Stacklands"
+    exeNames:
+      - "Stacklands.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/starsand.yml
+++ b/games/data/generated/starsand.yml
@@ -9,43 +9,51 @@ distributions:
   - platform: "epic-games-store"
     identifier: "a774278c0813447c96a76b053cbf73ff"
 r2modman:
-  internalFolderName: "Starsand"
-  dataFolderName: "Starsand_Data"
-  settingsIdentifier: "Starsand"
-  packageIndex: "https://thunderstore.io/c/starsand/api/v1/package-listing-index/"
-  steamFolderName: "Starsand"
-  exeNames:
-    - "Starsand.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Starsand"
+      iconUrl: "Starsand.png"
+    internalFolderName: "Starsand"
+    dataFolderName: "Starsand_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1380220"
+      - platform: "epic-games-store"
+        identifier: "a774278c0813447c96a76b053cbf73ff"
+    settingsIdentifier: "Starsand"
+    packageIndex: "https://thunderstore.io/c/starsand/api/v1/package-listing-index/"
+    steamFolderName: "Starsand"
+    exeNames:
+      - "Starsand.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/straftat.yml
+++ b/games/data/generated/straftat.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2386720"
 r2modman:
-  internalFolderName: "STRAFTAT"
-  dataFolderName: "STRAFTAT_Data"
-  settingsIdentifier: "STRAFTAT"
-  packageIndex: "https://thunderstore.io/c/straftat/api/v1/package-listing-index/"
-  steamFolderName: "STRAFTAT"
-  exeNames:
-    - "STRAFTAT.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "STRAFTAT"
+      iconUrl: "STRAFTAT.png"
+    internalFolderName: "STRAFTAT"
+    dataFolderName: "STRAFTAT_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2386720"
+    settingsIdentifier: "STRAFTAT"
+    packageIndex: "https://thunderstore.io/c/straftat/api/v1/package-listing-index/"
+    steamFolderName: "STRAFTAT"
+    exeNames:
+      - "STRAFTAT.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/subnautica-below-zero.yml
+++ b/games/data/generated/subnautica-below-zero.yml
@@ -9,54 +9,62 @@ distributions:
   - platform: "xbox-game-pass"
     identifier: "UnknownWorldsEntertainmen.SubnauticaBelowZero"
 r2modman:
-  internalFolderName: "SubnauticaBZ"
-  dataFolderName: "SubnauticaZero_Data"
-  settingsIdentifier: "SubnauticaBZ"
-  packageIndex: "https://thunderstore.io/c/subnautica-below-zero/api/v1/package-listing-index/"
-  steamFolderName: "SubnauticaZero"
-  exeNames:
-    - "SubnauticaZero.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "bz"
-    - "sbz"
-    - "s:bz"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "QMods"
-      defaultFileExtensions: []
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions:
-    - "manifest.json"
-    - "icon.png"
-    - "README.md"
+  - meta:
+      displayName: "Subnautica: Below Zero"
+      iconUrl: "SubnauticaBelowZero.png"
+    internalFolderName: "SubnauticaBZ"
+    dataFolderName: "SubnauticaZero_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "848450"
+      - platform: "xbox-game-pass"
+        identifier: "UnknownWorldsEntertainmen.SubnauticaBelowZero"
+    settingsIdentifier: "SubnauticaBZ"
+    packageIndex: "https://thunderstore.io/c/subnautica-below-zero/api/v1/package-listing-index/"
+    steamFolderName: "SubnauticaZero"
+    exeNames:
+      - "SubnauticaZero.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "bz"
+      - "sbz"
+      - "s:bz"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "QMods"
+        defaultFileExtensions: []
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions:
+      - "manifest.json"
+      - "icon.png"
+      - "README.md"

--- a/games/data/generated/subnautica.yml
+++ b/games/data/generated/subnautica.yml
@@ -11,51 +11,61 @@ distributions:
   - platform: "xbox-game-pass"
     identifier: "UnknownWorldsEntertainmen.GAMEPREVIEWSubnautica"
 r2modman:
-  internalFolderName: "Subnautica"
-  dataFolderName: "Subnautica_Data"
-  settingsIdentifier: "Subnautica"
-  packageIndex: "https://thunderstore.io/c/subnautica/api/v1/package-listing-index/"
-  steamFolderName: "Subnautica"
-  exeNames:
-    - "Subnautica.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "QMods"
-      defaultFileExtensions: []
-      trackingMethod: "state"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions:
-    - "manifest.json"
-    - "icon.png"
-    - "README.md"
+  - meta:
+      displayName: "Subnautica"
+      iconUrl: "Subnautica.png"
+    internalFolderName: "Subnautica"
+    dataFolderName: "Subnautica_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "264710"
+      - platform: "epic-games-store"
+        identifier: "Jaguar"
+      - platform: "xbox-game-pass"
+        identifier: "UnknownWorldsEntertainmen.GAMEPREVIEWSubnautica"
+    settingsIdentifier: "Subnautica"
+    packageIndex: "https://thunderstore.io/c/subnautica/api/v1/package-listing-index/"
+    steamFolderName: "Subnautica"
+    exeNames:
+      - "Subnautica.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "QMods"
+        defaultFileExtensions: []
+        trackingMethod: "state"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions:
+      - "manifest.json"
+      - "icon.png"
+      - "README.md"

--- a/games/data/generated/subterranauts.yml
+++ b/games/data/generated/subterranauts.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "3075800"
 r2modman:
-  internalFolderName: "Subterranauts"
-  dataFolderName: "Subterranauts_Data"
-  settingsIdentifier: "Subterranauts"
-  packageIndex: "https://thunderstore.io/c/subterranauts/api/v1/package-listing-index/"
-  steamFolderName: "Subterranauts"
-  exeNames:
-    - "Subterranauts.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Subterranauts"
+      iconUrl: "Subterranauts.png"
+    internalFolderName: "Subterranauts"
+    dataFolderName: "Subterranauts_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "3075800"
+    settingsIdentifier: "Subterranauts"
+    packageIndex: "https://thunderstore.io/c/subterranauts/api/v1/package-listing-index/"
+    steamFolderName: "Subterranauts"
+    exeNames:
+      - "Subterranauts.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/subterror.yml
+++ b/games/data/generated/subterror.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2846060"
 r2modman:
-  internalFolderName: "Subterror"
-  dataFolderName: "Subterror_Data"
-  settingsIdentifier: "Subterror"
-  packageIndex: "https://thunderstore.io/c/subterror/api/v1/package-listing-index/"
-  steamFolderName: "Subterror"
-  exeNames:
-    - "Subterror.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "st"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Subterror"
+      iconUrl: "Subterror.png"
+    internalFolderName: "Subterror"
+    dataFolderName: "Subterror_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2846060"
+    settingsIdentifier: "Subterror"
+    packageIndex: "https://thunderstore.io/c/subterror/api/v1/package-listing-index/"
+    steamFolderName: "Subterror"
+    exeNames:
+      - "Subterror.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "st"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/sulfur.yml
+++ b/games/data/generated/sulfur.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2124120"
 r2modman:
-  internalFolderName: "SULFUR"
-  dataFolderName: "Sulfur_Data"
-  settingsIdentifier: "SULFUR"
-  packageIndex: "https://thunderstore.io/c/sulfur/api/v1/package-listing-index/"
-  steamFolderName: "Sulfur"
-  exeNames:
-    - "Sulfur.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "SULFUR"
+      iconUrl: "SULFUR.png"
+    internalFolderName: "SULFUR"
+    dataFolderName: "Sulfur_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2124120"
+    settingsIdentifier: "SULFUR"
+    packageIndex: "https://thunderstore.io/c/sulfur/api/v1/package-listing-index/"
+    steamFolderName: "Sulfur"
+    exeNames:
+      - "Sulfur.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/sun-haven.yml
+++ b/games/data/generated/sun-haven.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1432860"
 r2modman:
-  internalFolderName: "SunHaven"
-  dataFolderName: "SunHaven_Data"
-  settingsIdentifier: "SunHaven"
-  packageIndex: "https://thunderstore.io/c/sun-haven/api/v1/package-listing-index/"
-  steamFolderName: "Sun Haven"
-  exeNames:
-    - "Sun Haven.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "sh"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Sun Haven"
+      iconUrl: "sun-haven.jpg"
+    internalFolderName: "SunHaven"
+    dataFolderName: "SunHaven_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1432860"
+    settingsIdentifier: "SunHaven"
+    packageIndex: "https://thunderstore.io/c/sun-haven/api/v1/package-listing-index/"
+    steamFolderName: "Sun Haven"
+    exeNames:
+      - "Sun Haven.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "sh"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/sunkenland.yml
+++ b/games/data/generated/sunkenland.yml
@@ -7,43 +7,49 @@ distributions:
   - platform: "steam"
     identifier: "2080690"
 r2modman:
-  internalFolderName: "Sunkenland"
-  dataFolderName: "Sunkenland_Data"
-  settingsIdentifier: "Sunkenland"
-  packageIndex: "https://thunderstore.io/c/sunkenland/api/v1/package-listing-index/"
-  steamFolderName: "Sunkenland"
-  exeNames:
-    - "Sunkenland.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Sunkenland"
+      iconUrl: "Sunkenland.jpg"
+    internalFolderName: "Sunkenland"
+    dataFolderName: "Sunkenland_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2080690"
+    settingsIdentifier: "Sunkenland"
+    packageIndex: "https://thunderstore.io/c/sunkenland/api/v1/package-listing-index/"
+    steamFolderName: "Sunkenland"
+    exeNames:
+      - "Sunkenland.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/supermarket-together.yml
+++ b/games/data/generated/supermarket-together.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2709570"
 r2modman:
-  internalFolderName: "SupermarketTogether"
-  dataFolderName: "Supermarket Together_Data"
-  settingsIdentifier: "SupermarketTogether"
-  packageIndex: "https://thunderstore.io/c/supermarket-together/api/v1/package-listing-index/"
-  steamFolderName: "Supermarket Together"
-  exeNames:
-    - "Supermarket Together.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Supermarket Together"
+      iconUrl: "SupermarketTogether.png"
+    internalFolderName: "SupermarketTogether"
+    dataFolderName: "Supermarket Together_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2709570"
+    settingsIdentifier: "SupermarketTogether"
+    packageIndex: "https://thunderstore.io/c/supermarket-together/api/v1/package-listing-index/"
+    steamFolderName: "Supermarket Together"
+    exeNames:
+      - "Supermarket Together.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/talespire.yml
+++ b/games/data/generated/talespire.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "720620"
 r2modman:
-  internalFolderName: "TaleSpire"
-  dataFolderName: "TaleSpire_Data"
-  settingsIdentifier: "TaleSpire"
-  packageIndex: "https://thunderstore.io/c/talespire/api/v1/package-listing-index/"
-  steamFolderName: "TaleSpire"
-  exeNames:
-    - "TaleSpire.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "TS"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "TaleSpire"
+      iconUrl: "TaleSpire.jpg"
+    internalFolderName: "TaleSpire"
+    dataFolderName: "TaleSpire_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "720620"
+    settingsIdentifier: "TaleSpire"
+    packageIndex: "https://thunderstore.io/c/talespire/api/v1/package-listing-index/"
+    steamFolderName: "TaleSpire"
+    exeNames:
+      - "TaleSpire.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "TS"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/tank-team.yml
+++ b/games/data/generated/tank-team.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2587450"
 r2modman:
-  internalFolderName: "TankTeam"
-  dataFolderName: "Tank Team_Data"
-  settingsIdentifier: "TankTeam"
-  packageIndex: "https://thunderstore.io/c/tank-team/api/v1/package-listing-index/"
-  steamFolderName: "Tank Team"
-  exeNames:
-    - "Tank Team.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Tank Team"
+      iconUrl: "TankTeam.png"
+    internalFolderName: "TankTeam"
+    dataFolderName: "Tank Team_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2587450"
+    settingsIdentifier: "TankTeam"
+    packageIndex: "https://thunderstore.io/c/tank-team/api/v1/package-listing-index/"
+    steamFolderName: "Tank Team"
+    exeNames:
+      - "Tank Team.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/tcg-card-shop-simulator.yml
+++ b/games/data/generated/tcg-card-shop-simulator.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "3070070"
 r2modman:
-  internalFolderName: "TCGCardShopSimulator"
-  dataFolderName: "Card Shop Simulator_Data"
-  settingsIdentifier: "TCG Card Shop Simulator"
-  packageIndex: "https://thunderstore.io/c/tcg-card-shop-simulator/api/v1/package-listing-index/"
-  steamFolderName: "TCG Card Shop Simulator"
-  exeNames:
-    - "Card Shop Simulator.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "TCG Card Shop Simulator"
+      iconUrl: "TCGCardShopSimulator.png"
+    internalFolderName: "TCGCardShopSimulator"
+    dataFolderName: "Card Shop Simulator_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "3070070"
+    settingsIdentifier: "TCG Card Shop Simulator"
+    packageIndex: "https://thunderstore.io/c/tcg-card-shop-simulator/api/v1/package-listing-index/"
+    steamFolderName: "TCG Card Shop Simulator"
+    exeNames:
+      - "Card Shop Simulator.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/techtonica.yml
+++ b/games/data/generated/techtonica.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1457320"
 r2modman:
-  internalFolderName: "Techtonica"
-  dataFolderName: "Techtonica_Data"
-  settingsIdentifier: "Techtonica"
-  packageIndex: "https://thunderstore.io/c/techtonica/api/v1/package-listing-index/"
-  steamFolderName: "Techtonica"
-  exeNames:
-    - "Techtonica.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "tt"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Techtonica"
+      iconUrl: "techtonica.png"
+    internalFolderName: "Techtonica"
+    dataFolderName: "Techtonica_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1457320"
+    settingsIdentifier: "Techtonica"
+    packageIndex: "https://thunderstore.io/c/techtonica/api/v1/package-listing-index/"
+    steamFolderName: "Techtonica"
+    exeNames:
+      - "Techtonica.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "tt"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/the-ouroboros-king.yml
+++ b/games/data/generated/the-ouroboros-king.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2096510"
 r2modman:
-  internalFolderName: "TheOuroborosKing"
-  dataFolderName: "The Ouroboros King_Data"
-  settingsIdentifier: "TheOuroborosKing"
-  packageIndex: "https://thunderstore.io/c/the-ouroboros-king/api/v1/package-listing-index/"
-  steamFolderName: "The Ouroboros King"
-  exeNames:
-    - "The Ouroboros King.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "tok"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "The Ouroboros King"
+      iconUrl: "the-ouroboros-king.jpg"
+    internalFolderName: "TheOuroborosKing"
+    dataFolderName: "The Ouroboros King_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2096510"
+    settingsIdentifier: "TheOuroborosKing"
+    packageIndex: "https://thunderstore.io/c/the-ouroboros-king/api/v1/package-listing-index/"
+    steamFolderName: "The Ouroboros King"
+    exeNames:
+      - "The Ouroboros King.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "tok"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/the-planet-crafter.yml
+++ b/games/data/generated/the-planet-crafter.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1284190"
 r2modman:
-  internalFolderName: "ThePlanetCrafter"
-  dataFolderName: "ThePlanetCrafter_Data"
-  settingsIdentifier: "ThePlanetCrafter"
-  packageIndex: "https://thunderstore.io/c/the-planet-crafter/api/v1/package-listing-index/"
-  steamFolderName: "The Planet Crafter"
-  exeNames:
-    - "Planet Crafter.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "tpc"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "The Planet Crafter"
+      iconUrl: "the-planet-crafter.jpg"
+    internalFolderName: "ThePlanetCrafter"
+    dataFolderName: "ThePlanetCrafter_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1284190"
+    settingsIdentifier: "ThePlanetCrafter"
+    packageIndex: "https://thunderstore.io/c/the-planet-crafter/api/v1/package-listing-index/"
+    steamFolderName: "The Planet Crafter"
+    exeNames:
+      - "Planet Crafter.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "tpc"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/thronefall.yml
+++ b/games/data/generated/thronefall.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "2239150"
 r2modman:
-  internalFolderName: "Thronefall"
-  dataFolderName: "Thronefall_Data"
-  settingsIdentifier: "Thronefall"
-  packageIndex: "https://thunderstore.io/c/thronefall/api/v1/package-listing-index/"
-  steamFolderName: "Thronefall"
-  exeNames:
-    - "Thronefall.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "tf"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Thronefall"
+      iconUrl: "thronefall.png"
+    internalFolderName: "Thronefall"
+    dataFolderName: "Thronefall_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "2239150"
+    settingsIdentifier: "Thronefall"
+    packageIndex: "https://thunderstore.io/c/thronefall/api/v1/package-listing-index/"
+    steamFolderName: "Thronefall"
+    exeNames:
+      - "Thronefall.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "tf"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/timberborn.yml
+++ b/games/data/generated/timberborn.yml
@@ -11,49 +11,59 @@ distributions:
   - platform: "other"
     identifier: null
 r2modman:
-  internalFolderName: "Timberborn"
-  dataFolderName: "Timberborn_Data"
-  settingsIdentifier: "Timberborn"
-  packageIndex: "https://thunderstore.io/c/timberborn/api/v1/package-listing-index/"
-  steamFolderName: "Timberborn"
-  exeNames:
-    - "Timberborn.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "TB"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/Maps"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Timberborn"
+      iconUrl: "Timberborn.png"
+    internalFolderName: "Timberborn"
+    dataFolderName: "Timberborn_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1062090"
+      - platform: "epic-games-store"
+        identifier: "972a4ca2631e43b4ba7bc3b7586ad8c4"
+      - platform: "other"
+        identifier: null
+    settingsIdentifier: "Timberborn"
+    packageIndex: "https://thunderstore.io/c/timberborn/api/v1/package-listing-index/"
+    steamFolderName: "Timberborn"
+    exeNames:
+      - "Timberborn.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "TB"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/Maps"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/totally-accurate-battle-simulator.yml
+++ b/games/data/generated/totally-accurate-battle-simulator.yml
@@ -11,44 +11,54 @@ distributions:
   - platform: "xbox-game-pass"
     identifier: "LandfallGames.TotallyAccurateBattleSimulator"
 r2modman:
-  internalFolderName: "TABS"
-  dataFolderName: "TotallyAccurateBattleSimulator_Data"
-  settingsIdentifier: "TotallyAccurateBattleSimulator"
-  packageIndex: "https://thunderstore.io/c/totally-accurate-battle-simulator/api/v1/package-listing-index/"
-  steamFolderName: "Totally Accurate Battle Simulator"
-  exeNames:
-    - "TotallyAccurateBattleSimulator.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "Totally Accurate Battle Simulator"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "TABS"
+      iconUrl: "TotallyAccurateBattleSimulator.jpg"
+    internalFolderName: "TABS"
+    dataFolderName: "TotallyAccurateBattleSimulator_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "508440"
+      - platform: "epic-games-store"
+        identifier: "Driftfish"
+      - platform: "xbox-game-pass"
+        identifier: "LandfallGames.TotallyAccurateBattleSimulator"
+    settingsIdentifier: "TotallyAccurateBattleSimulator"
+    packageIndex: "https://thunderstore.io/c/totally-accurate-battle-simulator/api/v1/package-listing-index/"
+    steamFolderName: "Totally Accurate Battle Simulator"
+    exeNames:
+      - "TotallyAccurateBattleSimulator.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "Totally Accurate Battle Simulator"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/touhou-lost-branch-of-legend.yml
+++ b/games/data/generated/touhou-lost-branch-of-legend.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1140150"
 r2modman:
-  internalFolderName: "TouhouLostBranchOfLegend"
-  dataFolderName: "LBoL_Data"
-  settingsIdentifier: "TouhouLostBranchOfLegend"
-  packageIndex: "https://thunderstore.io/c/touhou-lost-branch-of-legend/api/v1/package-listing-index/"
-  steamFolderName: "LBoL"
-  exeNames:
-    - "LBoL.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "lbol"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "TouhouLostBranchOfLegend"
+      iconUrl: "TouhouLostBranchOfLegend.jpg"
+    internalFolderName: "TouhouLostBranchOfLegend"
+    dataFolderName: "LBoL_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1140150"
+    settingsIdentifier: "TouhouLostBranchOfLegend"
+    packageIndex: "https://thunderstore.io/c/touhou-lost-branch-of-legend/api/v1/package-listing-index/"
+    steamFolderName: "LBoL"
+    exeNames:
+      - "LBoL.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "lbol"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/trombone-champ.yml
+++ b/games/data/generated/trombone-champ.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1059990"
 r2modman:
-  internalFolderName: "TromboneChamp"
-  dataFolderName: "TromboneChamp_Data"
-  settingsIdentifier: "TromboneChamp"
-  packageIndex: "https://thunderstore.io/c/trombone-champ/api/v1/package-listing-index/"
-  steamFolderName: "TromboneChamp"
-  exeNames:
-    - "TromboneChamp.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "tc"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Trombone Champ"
+      iconUrl: "TromboneChamp.jpg"
+    internalFolderName: "TromboneChamp"
+    dataFolderName: "TromboneChamp_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1059990"
+    settingsIdentifier: "TromboneChamp"
+    packageIndex: "https://thunderstore.io/c/trombone-champ/api/v1/package-listing-index/"
+    steamFolderName: "TromboneChamp"
+    exeNames:
+      - "TromboneChamp.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "tc"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/ultimate-chicken-horse.yml
+++ b/games/data/generated/ultimate-chicken-horse.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "386940"
 r2modman:
-  internalFolderName: "UltimateChickenHorse"
-  dataFolderName: "UltimateChickenHorse_Data"
-  settingsIdentifier: "UltimateChickenHorse"
-  packageIndex: "https://thunderstore.io/c/ultimate-chicken-horse/api/v1/package-listing-index/"
-  steamFolderName: "Ultimate Chicken Horse"
-  exeNames:
-    - "UltimateChickenHorse.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "uch"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Ultimate Chicken Horse"
+      iconUrl: "ultimate-chicken-horse.jpg"
+    internalFolderName: "UltimateChickenHorse"
+    dataFolderName: "UltimateChickenHorse_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "386940"
+    settingsIdentifier: "UltimateChickenHorse"
+    packageIndex: "https://thunderstore.io/c/ultimate-chicken-horse/api/v1/package-listing-index/"
+    steamFolderName: "Ultimate Chicken Horse"
+    exeNames:
+      - "UltimateChickenHorse.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "uch"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/ultrakill.yml
+++ b/games/data/generated/ultrakill.yml
@@ -7,49 +7,55 @@ distributions:
   - platform: "steam"
     identifier: "1229490"
 r2modman:
-  internalFolderName: "ULTRAKILL"
-  dataFolderName: "ULTRAKILL_Data"
-  settingsIdentifier: "ULTRAKILL"
-  packageIndex: "https://thunderstore.io/c/ultrakill/api/v1/package-listing-index/"
-  steamFolderName: "ULTRAKILL"
-  exeNames:
-    - "ULTRAKILL.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "uk"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/UMM Mods"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "ULTRAKILL"
+      iconUrl: "ULTRAKILL.jpg"
+    internalFolderName: "ULTRAKILL"
+    dataFolderName: "ULTRAKILL_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1229490"
+    settingsIdentifier: "ULTRAKILL"
+    packageIndex: "https://thunderstore.io/c/ultrakill/api/v1/package-listing-index/"
+    steamFolderName: "ULTRAKILL"
+    exeNames:
+      - "ULTRAKILL.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "uk"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/UMM Mods"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/v-rising.yml
+++ b/games/data/generated/v-rising.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1604030"
 r2modman:
-  internalFolderName: "VRising"
-  dataFolderName: "VRising_Data"
-  settingsIdentifier: "VRising"
-  packageIndex: "https://thunderstore.io/c/v-rising/api/v1/package-listing-index/"
-  steamFolderName: "VRising"
-  exeNames:
-    - "VRising.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "vrising"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "V Rising"
+      iconUrl: "VRising.jpg"
+    internalFolderName: "VRising"
+    dataFolderName: "VRising_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1604030"
+    settingsIdentifier: "VRising"
+    packageIndex: "https://thunderstore.io/c/v-rising/api/v1/package-listing-index/"
+    steamFolderName: "VRising"
+    exeNames:
+      - "VRising.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "vrising"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/valheim.yml
+++ b/games/data/generated/valheim.yml
@@ -8,50 +8,114 @@ distributions:
     identifier: "892970"
   - platform: "xbox-game-pass"
     identifier: "CoffeeStainStudios.Valheim"
+  - platform: "steam"
+    identifier: "896660"
 r2modman:
-  internalFolderName: "Valheim"
-  dataFolderName: "valheim_Data"
-  settingsIdentifier: "Valheim"
-  packageIndex: "https://thunderstore.io/c/valheim/api/v1/package-listing-index/"
-  steamFolderName: "Valheim"
-  exeNames:
-    - "valheim.exe"
-    - "valheim.x86_64"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/SlimVML"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Valheim"
+      iconUrl: "Valheim.jpg"
+    internalFolderName: "Valheim"
+    dataFolderName: "valheim_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "892970"
+      - platform: "xbox-game-pass"
+        identifier: "CoffeeStainStudios.Valheim"
+      - platform: "steam"
+        identifier: "896660"
+    settingsIdentifier: "Valheim"
+    packageIndex: "https://thunderstore.io/c/valheim/api/v1/package-listing-index/"
+    steamFolderName: "Valheim"
+    exeNames:
+      - "valheim.exe"
+      - "valheim.x86_64"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/SlimVML"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null
+  - meta:
+      displayName: "Valheim Dedicated Server"
+      iconUrl: "Valheim.jpg"
+    internalFolderName: "Valheim"
+    dataFolderName: "valheim_server_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "896660"
+    settingsIdentifier: "ValheimServer"
+    packageIndex: "https://thunderstore.io/c/valheim/api/v1/package-listing-index/"
+    steamFolderName: "Valheim dedicated server"
+    exeNames:
+      - "valheim_server.exe"
+      - "valheim_server.x86_64"
+    gameInstanceType: "server"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/SlimVML"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/vertigo-2.yml
+++ b/games/data/generated/vertigo-2.yml
@@ -7,43 +7,49 @@ distributions:
   - platform: "steam"
     identifier: "843390"
 r2modman:
-  internalFolderName: "Vertigo2"
-  dataFolderName: "vertigo2_Data"
-  settingsIdentifier: "Vertigo2"
-  packageIndex: "https://thunderstore.io/c/vertigo-2/api/v1/package-listing-index/"
-  steamFolderName: "Vertigo 2"
-  exeNames:
-    - "vertigo2.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Vertigo 2"
+      iconUrl: "Vertigo2.png"
+    internalFolderName: "Vertigo2"
+    dataFolderName: "vertigo2_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "843390"
+    settingsIdentifier: "Vertigo2"
+    packageIndex: "https://thunderstore.io/c/vertigo-2/api/v1/package-listing-index/"
+    steamFolderName: "Vertigo 2"
+    exeNames:
+      - "vertigo2.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/voices-of-the-void.yml
+++ b/games/data/generated/voices-of-the-void.yml
@@ -7,17 +7,23 @@ distributions:
   - platform: "other"
     identifier: null
 r2modman:
-  internalFolderName: "VotV"
-  dataFolderName: "VotV"
-  settingsIdentifier: "VotV"
-  packageIndex: "https://thunderstore.io/c/voices-of-the-void/api/v1/package-listing-index/"
-  steamFolderName: ""
-  exeNames:
-    - "VotV.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "votv"
-  packageLoader: "shimloader"
-  installRules: []
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Voices of the Void"
+      iconUrl: "VotV.png"
+    internalFolderName: "VotV"
+    dataFolderName: "VotV"
+    distributions:
+      - platform: "other"
+        identifier: null
+    settingsIdentifier: "VotV"
+    packageIndex: "https://thunderstore.io/c/voices-of-the-void/api/v1/package-listing-index/"
+    steamFolderName: ""
+    exeNames:
+      - "VotV.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "votv"
+    packageLoader: "shimloader"
+    installRules: []
+    relativeFileExclusions: null

--- a/games/data/generated/void-crew.yml
+++ b/games/data/generated/void-crew.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1063420"
 r2modman:
-  internalFolderName: "VoidCrew"
-  dataFolderName: "VoidCrew_Data"
-  settingsIdentifier: "VoidCrew"
-  packageIndex: "https://thunderstore.io/c/void-crew/api/v1/package-listing-index/"
-  steamFolderName: "Void Crew"
-  exeNames:
-    - "Void Crew.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "vc"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Void Crew"
+      iconUrl: "VoidCrew.png"
+    internalFolderName: "VoidCrew"
+    dataFolderName: "VoidCrew_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1063420"
+    settingsIdentifier: "VoidCrew"
+    packageIndex: "https://thunderstore.io/c/void-crew/api/v1/package-listing-index/"
+    steamFolderName: "Void Crew"
+    exeNames:
+      - "Void Crew.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "vc"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/vtol-vr.yml
+++ b/games/data/generated/vtol-vr.yml
@@ -7,43 +7,49 @@ distributions:
   - platform: "steam"
     identifier: "667970"
 r2modman:
-  internalFolderName: "VTOL_VR"
-  dataFolderName: "VTOLVR_Data"
-  settingsIdentifier: "VTOL_VR"
-  packageIndex: "https://thunderstore.io/c/vtol-vr/api/v1/package-listing-index/"
-  steamFolderName: "VTOL VR"
-  exeNames:
-    - "VTOLVR.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings: []
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "VTOL VR"
+      iconUrl: "VtolVR.jpg"
+    internalFolderName: "VTOL_VR"
+    dataFolderName: "VTOLVR_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "667970"
+    settingsIdentifier: "VTOL_VR"
+    packageIndex: "https://thunderstore.io/c/vtol-vr/api/v1/package-listing-index/"
+    steamFolderName: "VTOL VR"
+    exeNames:
+      - "VTOLVR.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/we-love-katamari-reroll-royal-reverie.yml
+++ b/games/data/generated/we-love-katamari-reroll-royal-reverie.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1730700"
 r2modman:
-  internalFolderName: "WeLoveKatamariRerollRoyalReverie"
-  dataFolderName: "WeLoveKatamariRerollRoyalReverie_Data"
-  settingsIdentifier: "WeLoveKatamariRerollRoyalReverie"
-  packageIndex: "https://thunderstore.io/c/we-love-katamari-reroll-royal-reverie/api/v1/package-listing-index/"
-  steamFolderName: "WLKRR"
-  exeNames:
-    - "WLKRR.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "wlkrr"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "We Love Katamari REROLL+ Royal Reverie"
+      iconUrl: "WLKRR.jpg"
+    internalFolderName: "WeLoveKatamariRerollRoyalReverie"
+    dataFolderName: "WeLoveKatamariRerollRoyalReverie_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1730700"
+    settingsIdentifier: "WeLoveKatamariRerollRoyalReverie"
+    packageIndex: "https://thunderstore.io/c/we-love-katamari-reroll-royal-reverie/api/v1/package-listing-index/"
+    steamFolderName: "WLKRR"
+    exeNames:
+      - "WLKRR.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "wlkrr"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/webfishing.yml
+++ b/games/data/generated/webfishing.yml
@@ -7,17 +7,23 @@ distributions:
   - platform: "steam"
     identifier: "3146520"
 r2modman:
-  internalFolderName: "WEBFISHING"
-  dataFolderName: ""
-  settingsIdentifier: "WEBFISHING"
-  packageIndex: "https://thunderstore.io/c/webfishing/api/v1/package-listing-index/"
-  steamFolderName: "WEBFISHING"
-  exeNames:
-    - "webfishing.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "gdweave"
-  installRules: []
-  relativeFileExclusions: null
+  - meta:
+      displayName: "WEBFISHING"
+      iconUrl: "WEBFISHING.png"
+    internalFolderName: "WEBFISHING"
+    dataFolderName: ""
+    distributions:
+      - platform: "steam"
+        identifier: "3146520"
+    settingsIdentifier: "WEBFISHING"
+    packageIndex: "https://thunderstore.io/c/webfishing/api/v1/package-listing-index/"
+    steamFolderName: "WEBFISHING"
+    exeNames:
+      - "webfishing.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "gdweave"
+    installRules: []
+    relativeFileExclusions: null

--- a/games/data/generated/west-of-loathing.yml
+++ b/games/data/generated/west-of-loathing.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "597220"
 r2modman:
-  internalFolderName: "WestofLoathing"
-  dataFolderName: "WestofLoathing_Data"
-  settingsIdentifier: "WestofLoathing"
-  packageIndex: "https://thunderstore.io/c/west-of-loathing/api/v1/package-listing-index/"
-  steamFolderName: "West of Loathing"
-  exeNames:
-    - "West of Loathing.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "wol"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "West of Loathing"
+      iconUrl: "west-of-loathing.jpg"
+    internalFolderName: "WestofLoathing"
+    dataFolderName: "WestofLoathing_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "597220"
+    settingsIdentifier: "WestofLoathing"
+    packageIndex: "https://thunderstore.io/c/west-of-loathing/api/v1/package-listing-index/"
+    steamFolderName: "West of Loathing"
+    exeNames:
+      - "West of Loathing.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "wol"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/white-knuckle.yml
+++ b/games/data/generated/white-knuckle.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "3195790"
 r2modman:
-  internalFolderName: "WhiteKnuckle"
-  dataFolderName: "White Knuckle_Data"
-  settingsIdentifier: "WhiteKnuckle"
-  packageIndex: "https://thunderstore.io/c/white-knuckle/api/v1/package-listing-index/"
-  steamFolderName: "White Knuckle Demo"
-  exeNames:
-    - "White Knuckle.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "wk"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "White Knuckle"
+      iconUrl: "WhiteKnuckle.png"
+    internalFolderName: "WhiteKnuckle"
+    dataFolderName: "White Knuckle_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "3195790"
+    settingsIdentifier: "WhiteKnuckle"
+    packageIndex: "https://thunderstore.io/c/white-knuckle/api/v1/package-listing-index/"
+    steamFolderName: "White Knuckle Demo"
+    exeNames:
+      - "White Knuckle.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "wk"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/wildfrost.yml
+++ b/games/data/generated/wildfrost.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1811990"
 r2modman:
-  internalFolderName: "Wildfrost"
-  dataFolderName: "Wildfrost_Data"
-  settingsIdentifier: "Wildfrost"
-  packageIndex: "https://thunderstore.io/c/wildfrost/api/v1/package-listing-index/"
-  steamFolderName: "Wildfrost"
-  exeNames:
-    - "Wildfrost.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "wfrst"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Wildfrost"
+      iconUrl: "wildfrost.jpg"
+    internalFolderName: "Wildfrost"
+    dataFolderName: "Wildfrost_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1811990"
+    settingsIdentifier: "Wildfrost"
+    packageIndex: "https://thunderstore.io/c/wildfrost/api/v1/package-listing-index/"
+    steamFolderName: "Wildfrost"
+    exeNames:
+      - "Wildfrost.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "wfrst"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/wizard-of-legend.yml
+++ b/games/data/generated/wizard-of-legend.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "445980"
 r2modman:
-  internalFolderName: "WizardOfLegend"
-  dataFolderName: "WizardOfLegend_Data"
-  settingsIdentifier: "WizardOfLegend"
-  packageIndex: "https://thunderstore.io/c/wizard-of-legend/api/v1/package-listing-index/"
-  steamFolderName: "Wizard of Legend"
-  exeNames:
-    - "WizardOfLegend.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "wol"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Wizard of Legend"
+      iconUrl: "WizardOfLegend.jpg"
+    internalFolderName: "WizardOfLegend"
+    dataFolderName: "WizardOfLegend_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "445980"
+    settingsIdentifier: "WizardOfLegend"
+    packageIndex: "https://thunderstore.io/c/wizard-of-legend/api/v1/package-listing-index/"
+    steamFolderName: "Wizard of Legend"
+    exeNames:
+      - "WizardOfLegend.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "wol"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/wizard-with-a-gun.yml
+++ b/games/data/generated/wizard-with-a-gun.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1150530"
 r2modman:
-  internalFolderName: "WizardWithAGun"
-  dataFolderName: "wizardwithagun_Data"
-  settingsIdentifier: "WizardWithAGun"
-  packageIndex: "https://thunderstore.io/c/wizard-with-a-gun/api/v1/package-listing-index/"
-  steamFolderName: "Wizard With A Gun"
-  exeNames:
-    - "wizardwithagun.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "wizgun"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Wizard With A Gun"
+      iconUrl: "WizardWithAGun.jpg"
+    internalFolderName: "WizardWithAGun"
+    dataFolderName: "wizardwithagun_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1150530"
+    settingsIdentifier: "WizardWithAGun"
+    packageIndex: "https://thunderstore.io/c/wizard-with-a-gun/api/v1/package-listing-index/"
+    steamFolderName: "Wizard With A Gun"
+    exeNames:
+      - "wizardwithagun.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "wizgun"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/wrestling-empire.yml
+++ b/games/data/generated/wrestling-empire.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "1620340"
 r2modman:
-  internalFolderName: "WrestlingEmpire"
-  dataFolderName: "Wrestling Empire_Data"
-  settingsIdentifier: "WrestlingEmpire"
-  packageIndex: "https://thunderstore.io/c/wrestling-empire/api/v1/package-listing-index/"
-  steamFolderName: "Wrestling Empire"
-  exeNames:
-    - "Wrestling Empire.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - "we"
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Wrestling Empire"
+      iconUrl: "wrestling-empire.jpg"
+    internalFolderName: "WrestlingEmpire"
+    dataFolderName: "Wrestling Empire_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "1620340"
+    settingsIdentifier: "WrestlingEmpire"
+    packageIndex: "https://thunderstore.io/c/wrestling-empire/api/v1/package-listing-index/"
+    steamFolderName: "Wrestling Empire"
+    exeNames:
+      - "Wrestling Empire.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - "we"
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/data/generated/zort.yml
+++ b/games/data/generated/zort.yml
@@ -7,44 +7,50 @@ distributions:
   - platform: "steam"
     identifier: "3121110"
 r2modman:
-  internalFolderName: "Zort"
-  dataFolderName: "Zort_Data"
-  settingsIdentifier: "Zort"
-  packageIndex: "https://thunderstore.io/c/zort/api/v1/package-listing-index/"
-  steamFolderName: "Zort"
-  exeNames:
-    - "Zort.exe"
-  gameInstanceType: "game"
-  gameSelectionDisplayMode: "visible"
-  additionalSearchStrings:
-    - ""
-  packageLoader: "bepinex"
-  installRules:
-    - route: "BepInEx/plugins"
-      defaultFileExtensions:
-        - ".dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: true
-    - route: "BepInEx/core"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/patchers"
-      defaultFileExtensions: []
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/monomod"
-      defaultFileExtensions:
-        - ".mm.dll"
-      trackingMethod: "subdir"
-      subRoutes: []
-      isDefaultLocation: false
-    - route: "BepInEx/config"
-      defaultFileExtensions: []
-      trackingMethod: "none"
-      subRoutes: []
-      isDefaultLocation: false
-  relativeFileExclusions: null
+  - meta:
+      displayName: "Zort"
+      iconUrl: "zort.png"
+    internalFolderName: "Zort"
+    dataFolderName: "Zort_Data"
+    distributions:
+      - platform: "steam"
+        identifier: "3121110"
+    settingsIdentifier: "Zort"
+    packageIndex: "https://thunderstore.io/c/zort/api/v1/package-listing-index/"
+    steamFolderName: "Zort"
+    exeNames:
+      - "Zort.exe"
+    gameInstanceType: "game"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings:
+      - ""
+    packageLoader: "bepinex"
+    installRules:
+      - route: "BepInEx/plugins"
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: true
+      - route: "BepInEx/core"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/patchers"
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/monomod"
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+        isDefaultLocation: false
+      - route: "BepInEx/config"
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+        isDefaultLocation: false
+    relativeFileExclusions: null

--- a/games/src/models.ts
+++ b/games/src/models.ts
@@ -58,8 +58,10 @@ export interface ModmanInstallRule {
 }
 
 export interface GameModmanDefinition {
+  meta: GameDefinitionMeta;
   internalFolderName: string;
   dataFolderName: string;
+  distributions?: GameDistributionDefinition[];
   settingsIdentifier: string;
   packageIndex: string;
   // exclusionsUrl: string;
@@ -88,15 +90,17 @@ export interface ThunderstoreCommunityDefinition {
   shortDescription?: string;
 }
 
+type GameDefinitionMeta = {
+  displayName: string;
+  iconUrl?: string | null;
+};
+
 export interface GameDefinition {
   uuid: string;
   label: string;
-  meta: {
-    displayName: string;
-    iconUrl?: string | null;
-  };
+  meta: GameDefinitionMeta;
   distributions?: GameDistributionDefinition[];
-  r2modman?: GameModmanDefinition | null;
+  r2modman?: GameModmanDefinition[] | null;
   thunderstore?: ThunderstoreCommunityDefinition;
 }
 

--- a/games/src/schema/validator.ts
+++ b/games/src/schema/validator.ts
@@ -48,9 +48,20 @@ const installRuleSchema: z.ZodType<_installRuleSchema> =
     subRoutes: z.lazy(() => installRuleSchema.array()),
   });
 
+const distributionSchema = z.strictObject({
+  platform: z.enum(DistributionPlatformValues),
+  identifier: z.string().optional().nullable(),
+});
+const metaSchema = z.strictObject({
+  displayName: z.string(),
+  iconUrl: z.string().nullable(),
+});
+
 const r2modmanSchema = z.strictObject({
+  meta: metaSchema,
   internalFolderName: z.string(),
   dataFolderName: z.string(),
+  distributions: z.array(distributionSchema),
   settingsIdentifier: z.string(),
   packageIndex: z.string(),
   steamFolderName: z.string(),
@@ -66,19 +77,11 @@ const r2modmanSchema = z.strictObject({
 const gameSchema = z.strictObject({
   uuid: z.string().uuid(),
   label: slug,
-  meta: z.strictObject({
-    displayName: z.string(),
-    iconUrl: z.string().nullable(),
-  }),
-  distributions: z.array(
-    z.strictObject({
-      platform: z.enum(DistributionPlatformValues),
-      identifier: z.string().optional().nullable(),
-    })
-  ),
+  meta: metaSchema,
+  distributions: z.array(distributionSchema),
   thunderstore: communitySchema.optional(),
   tcli: z.object({}).passthrough().optional(), // TODO: Use strict object with schema
-  r2modman: r2modmanSchema.nullable(), // TODO: Use strict object with schema
+  r2modman: z.array(r2modmanSchema).nullable(),
 });
 
 export const ecosystemJsonSchema = z.strictObject({


### PR DESCRIPTION
Add support for multiple r2modman definitions per game, as some games
have dedicated server distributions (Risk of Rain 2, Valheim) and e.g.
Outwards & Outward DE use the same game identifier currently, requiring
them to co-exist

This is a temporary measure to get the JSON data usable by the mod
manager, but we should update the data structure to handle this more
intelligently. In particular, strongly linking communities and games
together might not make sense, especially after taking into
consideration multiple game distributions. There could be mods that only
work on specific game distributions while not working on others and
right now we have no way to make that distinction.