### PR TITLE
Remove Labyrinthine URLs

### DIFF
--- a/games/data/labyrinthine.yml
+++ b/games/data/labyrinthine.yml
@@ -27,7 +27,5 @@ thunderstore:
       name: "Modpacks"
       requireCategories:
         - "modpacks"
-  wikiUrl: "https://labyrinthine.fandom.com/wiki/Labyrinthine_Wiki"
-  discordUrl: "https://discord.com/invite/valkogamestudios"
   autolistPackageIds:
     - "LavaGang-MelonLoader"


### PR DESCRIPTION
The URLs are not related to modding the game.