### PR TITLE
Add 6 categories and update discord url for Last Train Outta Wormtown

### DIFF
--- a/games/data/last-train-outta-wormtown.yml
+++ b/games/data/last-train-outta-wormtown.yml
@@ -18,6 +18,18 @@ thunderstore:
       label: "Misc"
     audio:
       label: "Audio"
+    equipment:
+      label: "Equipment"
+    abilities:
+      label: "Abilities"
+    cosmetics:
+      label: "Cosmetics"
+    objectives:
+      label: "Objectives"
+    translations:
+      label: "Translations"
+    tweaks:
+      label: "Tweaks"
   sections:
     mods:
       name: "Mods"
@@ -28,4 +40,4 @@ thunderstore:
       requireCategories:
         - "modpacks"
   wikiUrl: "https://lasttrainouttawormtown.fandom.com/wiki/Last_Train_Outta'_Wormtown_Wiki"
-  discordUrl: "https://discord.gg/wormtown"
+  discordUrl: "https://discord.gg/bTpxn65ZzY"


### PR DESCRIPTION
- Add "Equipment" category
- Add "Abilities" category
- Add "Cosmetics" category
- Add "Objectives" category
- Add "Translations" category
- Add "Tweaks" category
- Update discord URL to be the modding discord instead of the discord for the game itself