### PR TITLE
Remove duplicate distributions from first r2modman item

### DIFF
--- a/games/data/generated/outward.yml
+++ b/games/data/generated/outward.yml
@@ -29,12 +29,6 @@ r2modman:
         identifier: "Viola"
       - platform: "other"
         identifier: null
-      - platform: "steam"
-        identifier: "1758860"
-      - platform: "epic-games-store"
-        identifier: "f07a51af8ac845ea96f792fb485e04a3"
-      - platform: "other"
-        identifier: null
     settingsIdentifier: "Outward"
     packageIndex: "https://thunderstore.io/c/outward/api/v1/package-listing-index/"
     steamFolderName: "Outward"

--- a/games/data/generated/riskofrain2.yml
+++ b/games/data/generated/riskofrain2.yml
@@ -21,8 +21,6 @@ r2modman:
         identifier: "632360"
       - platform: "epic-games-store"
         identifier: "4b3dcc5723454a47a9112d8fe8fd5f5c"
-      - platform: "steam"
-        identifier: "1180760"
     settingsIdentifier: "RiskOfRain2"
     packageIndex: "https://thunderstore.io/c/riskofrain2/api/v1/package-listing-index/"
     steamFolderName: "Risk of Rain 2"

--- a/games/data/generated/valheim.yml
+++ b/games/data/generated/valheim.yml
@@ -21,8 +21,6 @@ r2modman:
         identifier: "892970"
       - platform: "xbox-game-pass"
         identifier: "CoffeeStainStudios.Valheim"
-      - platform: "steam"
-        identifier: "896660"
     settingsIdentifier: "Valheim"
     packageIndex: "https://thunderstore.io/c/valheim/api/v1/package-listing-index/"
     steamFolderName: "Valheim"

--- a/games/src/scripts/extract-r2modman.ts
+++ b/games/src/scripts/extract-r2modman.ts
@@ -144,24 +144,14 @@ for (const definitions of gamesByCommunityId.values()) {
   if (definitions.length < 1) {
     continue;
   }
-  const result = definitions[0];
-  for (const entry of definitions.slice(1)) {
-    if (!entry.r2modman) {
-      continue;
-    }
-    if (!result.r2modman) {
-      result.r2modman = [];
-    }
-    result.r2modman.push(...entry.r2modman);
 
-    if (entry.distributions) {
-      if (!result.distributions) {
-        result.distributions = [];
-      }
-      result.distributions.push(...entry.distributions);
-    }
-  }
-  games.push(result);
+  const allR2Modman = definitions.flatMap((x) => x.r2modman ?? []);
+
+  games.push({
+    ...definitions[0],
+    distributions: definitions.flatMap((x) => x.distributions ?? []),
+    r2modman: allR2Modman.length ? allR2Modman : null,
+  });
 }
 
 fs.writeFileSync(


### PR DESCRIPTION
Code that collected distributions from different r2modman items (e.g. a game and a server) to root level distributions item inadvertently overwrote the distributions of the first r2modman item with the same values. Now each r2modman item retains their own distributions while the root level distributions contain the combined values.

This still leaves an issue with the current data where Outwards has "other" distribution twice in the root level distributions, since both the regular and the definitive edition of the game support this. As the mod managers don't actually use the root level distributions item, it's no concern to me.