### PR TITLE
Remove InstallRules and RelativeFileExclusions from Painting VR

### DIFF
--- a/games/data/generated/painting-vr.yml
+++ b/games/data/generated/painting-vr.yml
@@ -25,42 +25,5 @@ r2modman:
     additionalSearchStrings:
       - "pvr"
     packageLoader: "recursive-melonloader"
-    installRules:
-      - route: "Mods"
-        defaultFileExtensions:
-          - ".dll"
-        trackingMethod: "state"
-        subRoutes: []
-        isDefaultLocation: false
-      - route: "UserData/ModManager"
-        defaultFileExtensions: []
-        trackingMethod: "subdir-no-flatten"
-        subRoutes: []
-        isDefaultLocation: true
-      - route: "UserLibs"
-        defaultFileExtensions:
-          - ".lib.dll"
-        trackingMethod: "state"
-        subRoutes: []
-        isDefaultLocation: false
-      - route: "MelonLoader"
-        defaultFileExtensions: []
-        trackingMethod: "state"
-        subRoutes:
-          - route: "Managed"
-            defaultFileExtensions:
-              - ".managed.dll"
-            trackingMethod: "state"
-            subRoutes: []
-            isDefaultLocation: false
-          - route: "Libs"
-            defaultFileExtensions: []
-            trackingMethod: "state"
-            subRoutes: []
-            isDefaultLocation: false
-        isDefaultLocation: false
-    relativeFileExclusions:
-      - "manifest.json"
-      - "icon.png"
-      - "README.md"
-      - "LICENCE"
+    installRules: []
+    relativeFileExclusions: null


### PR DESCRIPTION
The fields are not used by recursive MelonLoader and can therefore cause confusion. I'm not entirely sure how they ended up in the generated data - probably due to a bug in the extraction script.