### PR TITLE
Add "Vehicles" category for Lethal Company

### DIFF
--- a/games/data/lethal-company.yml
+++ b/games/data/lethal-company.yml
@@ -42,6 +42,8 @@ thunderstore:
       label: "Interiors"
     furniture:
       label: "Furniture"
+    vehicles:
+      label: "Vehicles"
     clientside:
       label: "Client-side"
     serverside:


### PR DESCRIPTION
This would help with discoverability for the many Cruiser related mods as well as any mods which add new vehicles.