### PR TITLE
Add categories "Emotes" and "Assets" to Atlyss tags.

### DIFF
--- a/games/data/atlyss.yml
+++ b/games/data/atlyss.yml
@@ -20,6 +20,10 @@ thunderstore:
       label: "Audio"
     maps:
       label: "Maps"
+    assets:
+      label: "Assets"
+    emotes:
+      label: "Emotes"
   sections:
     mods:
       name: "Mods"


### PR DESCRIPTION
Since we have mods that do custom emotes and custom assets for the game, this should be appropriate for the modding community of Atlyss.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added two new Thunderstore categories for ATLYSS: Assets and Emotes.
  * These categories appear alongside existing ones in category lists, enabling users to browse and filter content under Assets and Emotes.
  * Improves organization and discovery of related content within the Thunderstore browsing experience for ATLYSS users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->