### PR TITLE
Added relevant categories/tags for white knuckle

### DIFF
--- a/games/data/white-knuckle.yml
+++ b/games/data/white-knuckle.yml
@@ -18,6 +18,30 @@ thunderstore:
       label: "Misc"
     audio:
       label: "Audio"
+    hand-cosmetics:
+      label: "Hand Cosmetics"
+    hand-packs:
+      label: "Hand Packs"
+    maps:
+      label: "Maps"
+    levels:
+      label: "Levels"
+    gamemodes:
+      label: "Gamemodes"
+    tweaks:
+      label: "Tweaks"
+    leaderboard-legal:
+      label: "Leaderboard Legal"
+    language:
+      label: "Language"
+    buffs:
+      label: "Buffs"
+    artifacts:
+      label: "Artifacts"
+    items:
+      label: "Items"
+    perks:
+      label: "Perks"
   sections:
     mods:
       name: "Mods"


### PR DESCRIPTION
I added relevant tags for the game, as there are more and more mods, that didn't fit the default categories, I added them. All the categories I added were decided on the official discord server by the community.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added 12 new Thunderstore categories for White Knuckle: Hand Cosmetics, Hand Packs, Maps, Levels, Gamemodes, Tweaks, Leaderboard Legal, Language, Buffs, Artifacts, Items, and Perks.
  * These categories are now available for organizing and discovering relevant content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->