### PR TITLE
Add a new game: Darkwater

### DIFF
--- a/games/data/darkwater.yml
+++ b/games/data/darkwater.yml
@@ -1,0 +1,79 @@
+uuid: "fde8a66c-d967-4505-adf3-5d9fe27bcc58"
+label: "darkwater"
+meta:
+  displayName: "Darkwater"
+  iconUrl: "darkwater.webp"
+distributions: []
+r2modman:
+  - gameInstanceType: "game"
+    distributions:
+      - platform: "steam"
+        identifier: "619540"
+    steamFolderName: "Darkwater"
+    dataFolderName: "Darkwater_Data"
+    exeNames:
+      - "Darkwater.exe"
+    packageLoader: "bepinex"
+    meta:
+      displayName: "Darkwater"
+      iconUrl: "darkwater.webp"
+    settingsIdentifier: "Darkwater"
+    internalFolderName: "Darkwater"
+    packageIndex: "https://thunderstore.io/c/darkwater/api/v1/package-listing-index/"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: ["dw"]
+    installRules:
+      - route: "BepInEx/plugins"
+        isDefaultLocation: true
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+      - route: "BepInEx/core"
+        isDefaultLocation: false
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+      - route: "BepInEx/patchers"
+        isDefaultLocation: false
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+      - route: "BepInEx/monomod"
+        isDefaultLocation: false
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+      - route: "BepInEx/config"
+        isDefaultLocation: false
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+    relativeFileExclusions: null
+thunderstore:
+  displayName: "Darkwater"
+  categories:
+    mods:
+      label: "Mods"
+    modpacks:
+      label: "Modpacks"
+    tools:
+      label: "Tools"
+    libraries:
+      label: "Libraries"
+    misc:
+      label: "Misc"
+    audio:
+      label: "Audio"
+  sections:
+    mods:
+      name: "Mods"
+      excludeCategories:
+        - "modpacks"
+    modpacks:
+      name: "Modpacks"
+      requireCategories:
+        - "modpacks"
+  autolistPackageIds:
+    - "BepInEx-BepInExPack"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Darkwater, now visible in game selection.
  * Enabled Thunderstore integration for Darkwater with categorized browsing (Mods, Modpacks) and filters.
  * Configured BepInEx as the package loader with install rules for plugins, core, patchers, monomod, and config to ensure correct deployment.
  * Automatic Steam detection and path handling for Darkwater.
  * Pre-populates the BepInEx pack for easier first-time setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->