### PR TITLE
Add a new game: Paper Animal Adventure

### DIFF
--- a/games/data/paper-animal-adventure.yml
+++ b/games/data/paper-animal-adventure.yml
@@ -1,0 +1,79 @@
+uuid: "c0935537-9ac9-43f6-9c30-64c4dd5945d1"
+label: "paper-animal-adventure"
+meta:
+  displayName: "Paper Animal Adventure"
+  iconUrl: "paper-animal-adventure.webp"
+distributions: []
+r2modman:
+  - gameInstanceType: "game"
+    distributions:
+      - platform: "steam"
+        identifier: "1982120"
+    steamFolderName: "Paper Animal Adventure"
+    dataFolderName: "Paper Animal Adventure_Data"
+    exeNames:
+      - "Paper Animal Adventure.exe"
+    packageLoader: "bepinex"
+    meta:
+      displayName: "Paper Animal Adventure"
+      iconUrl: "paper-animal-adventure.webp"
+    settingsIdentifier: "PaperAnimalAdventure"
+    internalFolderName: "PaperAnimalAdventure"
+    packageIndex: "https://thunderstore.io/c/paper-animal-adventure/api/v1/package-listing-index/"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: ["paa"]
+    installRules:
+      - route: "BepInEx/plugins"
+        isDefaultLocation: true
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+      - route: "BepInEx/core"
+        isDefaultLocation: false
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+      - route: "BepInEx/patchers"
+        isDefaultLocation: false
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+      - route: "BepInEx/monomod"
+        isDefaultLocation: false
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+      - route: "BepInEx/config"
+        isDefaultLocation: false
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+    relativeFileExclusions: null
+thunderstore:
+  displayName: "Paper Animal Adventure"
+  categories:
+    mods:
+      label: "Mods"
+    modpacks:
+      label: "Modpacks"
+    tools:
+      label: "Tools"
+    libraries:
+      label: "Libraries"
+    misc:
+      label: "Misc"
+    audio:
+      label: "Audio"
+  sections:
+    mods:
+      name: "Mods"
+      excludeCategories:
+        - "modpacks"
+    modpacks:
+      name: "Modpacks"
+      requireCategories:
+        - "modpacks"
+  autolistPackageIds:
+    - "BepInEx-BepInExPack_IL2CPP"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for Paper Animal Adventure in the mod manager.
  - Game appears in selection with icon and display name; Steam version auto-detected.
  - Supports BepInEx-based mods with correct install routing (plugins, core, patchers, monomod, config).
  - Integrated Thunderstore browsing for this game with Mods and Modpacks sections and relevant categories.
  - Automatically suggests the BepInEx IL2CPP pack for easy setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->