### PR TITLE
Add Resonite

### DIFF
--- a/games/data/resonite.yml
+++ b/games/data/resonite.yml
@@ -1,0 +1,106 @@
+uuid: "f5859576-bdf8-40bb-b08b-69f5506199a4"
+label: "resonite"
+meta:
+  displayName: "Resonite"
+  iconUrl: "resonite.webp"
+distributions: []
+r2modman:
+  - gameInstanceType: "game"
+    distributions:
+      - platform: "steam"
+        identifier: "2519830"
+    steamFolderName: "Resonite"
+    dataFolderName: "Resonite_Data"
+    exeNames:
+      - "Resonite.exe"
+    packageLoader: "bepinex"
+    meta:
+      displayName: "Resonite"
+      iconUrl: "resonite.webp"
+    settingsIdentifier: "Resonite"
+    internalFolderName: "Resonite"
+    packageIndex: "https://thunderstore.io/c/resonite/api/v1/package-listing-index/"
+    gameSelectionDisplayMode: "visible"
+    additionalSearchStrings: []
+    installRules:
+      - route: "BepInEx/plugins"
+        isDefaultLocation: true
+        defaultFileExtensions:
+          - ".dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+      - route: "BepInEx/core"
+        isDefaultLocation: false
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+      - route: "BepInEx/patchers"
+        isDefaultLocation: false
+        defaultFileExtensions: []
+        trackingMethod: "subdir"
+        subRoutes: []
+      - route: "BepInEx/monomod"
+        isDefaultLocation: false
+        defaultFileExtensions:
+          - ".mm.dll"
+        trackingMethod: "subdir"
+        subRoutes: []
+      - route: "BepInEx/config"
+        isDefaultLocation: false
+        defaultFileExtensions: []
+        trackingMethod: "none"
+        subRoutes: []
+    relativeFileExclusions: null
+thunderstore:
+  displayName: "Resonite"
+  categories:
+    mods:
+      label: "Mods"
+    modpacks:
+      label: "Modpacks"
+    tools:
+      label: "Tools"
+    libraries:
+      label: "Libraries"
+    misc:
+      label: "Misc"
+    audio:
+      label: "Audio"
+    assetimporting:
+      label: "Asset Importing"
+    bugworkaround:
+      label: "Bug Workaround"
+    contextmenu:
+      label: "Context Menu"
+    controls:
+      label: "Controls"
+    dashboard:
+      label: "Dashboard"
+    hardwareintegration:
+      label: "Hardware Integration"
+    inspectors:
+      label: "Inspectors"
+    memes:
+      label: "Memes"
+    optimization:
+      label: "Optimization"
+    protoflux:
+      label: "Protoflux"
+    technicaltweaks:
+      label: "Technical Tweaks"
+    visualtweaks:
+      label: "Visual Tweaks"
+    wizards:
+      label: "Wizards"
+  sections:
+    mods:
+      name: "Mods"
+      excludeCategories:
+        - "modpacks"
+    modpacks:
+      name: "Modpacks"
+      requireCategories:
+        - "modpacks"
+  discordUrl: "https://discord.gg/vCDJK9xyvm"
+  wikiUrl: "https://modding.resonite.net"
+  autolistPackageIds: []


### PR DESCRIPTION
Attempt at adding \[Resonite](https://store.steampowered.com/app/2519830/Resonite/) to thunderstore. We will make a discord forum post on this. 



CC @art0007i @knackrack615 @NepuShiro @EIA485



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full support for the Resonite game in the mod manager.
  * Enables Thunderstore integration with categorized browsing (mods, tools, libraries, etc.) and dedicated Mods/Modpacks sections.
  * Supports Steam detection and proper BepInEx installation routes (plugins, core, patchers, monomod, config).
  * Displays Resonite in game selection with icon and labels.
  * Provides helpful links to the community Discord and wiki for guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->