### PR TITLE
PEAK - Added mixtapes tag

### DIFF
--- a/games/data/peak.yml
+++ b/games/data/peak.yml
@@ -44,6 +44,8 @@ thunderstore:
       label: "Accolades"
     asset-replacements:
       label: "Asset Replacements"
+    mixtapes:
+      label: "Mixtapes"
   sections:
     mods:
       name: "Mods"


### PR DESCRIPTION
The PEAK community is getting a lot of mixtape mods, and although we have the sound tag mixtapes should be further separated for people that want sound mods but not mixtapes.