### PR TITLE
Revert "Add BepisLoader" and hide Resonite from mod managers

### DIFF
--- a/games/data/resonite.yml
+++ b/games/data/resonite.yml
@@ -13,14 +13,14 @@ r2modman:
     dataFolderName: "Resonite_Data"
     exeNames:
       - "Resonite.exe"
-    packageLoader: "bepisloader"
+    packageLoader: "bepinex"
     meta:
       displayName: "Resonite"
       iconUrl: "resonite.webp"
     settingsIdentifier: "Resonite"
     internalFolderName: "Resonite"
     packageIndex: "https://thunderstore.io/c/resonite/api/v1/package-listing-index/"
-    gameSelectionDisplayMode: "visible"
+    gameSelectionDisplayMode: "hidden"
     additionalSearchStrings: []
     installRules:
       - route: "BepInEx/plugins"

--- a/games/misc/modloader-packages.yml
+++ b/games/misc/modloader-packages.yml
@@ -208,6 +208,3 @@
 - packageId: "BepInEx-BepInExPack_Patapon"
   rootFolder: "BepInExPack"
   loader: "bepinex"
-- packageId: "ResoniteModding-BepisLoader"
-  rootFolder: "BepInExPack"
-  loader: "bepisloader"

--- a/games/src/models.ts
+++ b/games/src/models.ts
@@ -17,7 +17,6 @@ export const ModmanPackageLoaderValues = [
   "return-of-modding",
   "gdweave",
   "recursive-melonloader",
-  "bepisloader",
   "none",
 ] as const;
 export type ModmanPackageLoader = typeof ModmanPackageLoaderValues[number];

--- a/games/src/schema/packageLoaders.ts
+++ b/games/src/schema/packageLoaders.ts
@@ -34,8 +34,4 @@ export const PACKAGE_LOADER_CHOICES: PackageLoaderChoice[] = [
     value: "none",
     name: "None",
   },
-  {
-    value: 'bepisloader',
-    name: 'BepisLoader'
-  },
 ];


### PR DESCRIPTION
This reverts commit 19c210250eecc9c2900782f28d4ab4b4ac2e31da. Adding support for the game is currently blocked by technical problems, while having the changes available in the API blocks adding support for other games.