### PR TITLE
Chore: Update megabonk discord server link

### DIFF
--- a/games/data/megabonk.yml
+++ b/games/data/megabonk.yml
@@ -75,6 +75,6 @@ thunderstore:
       name: "Modpacks"
       requireCategories:
         - "modpacks"
-  discordUrl: "https://discord.gg/EcnegvM5nc"
+  discordUrl: "https://discord.gg/9VCRuEYTcq"
   autolistPackageIds:
     - "BepInEx-BepInExPack_IL2CPP"


### PR DESCRIPTION
Hi!

The current Discord link expired, so I generated a new permanent one (and directly to the modding channel)