### PR TITLE
[TS-3325] Add cover image DO deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,8 +33,8 @@ jobs:
         env:
           DO_SPACES_BUCKET: ${{ vars.DO_SPACES_BUCKET }}
           DO_SPACES_REGION: ${{ vars.DO_SPACES_REGION }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.DO_SPACES_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.DO_SPACES_SECRET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: "us-east-1"
       - name: "Deploy"
         run: "yarn run diff && yarn run deploy"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,7 +26,7 @@ jobs:
         run: "yarn run build"
       - name: "Deploy cover images"
         run: |
-          aws s3 sync ./cover_images/ "s3://$DO_SPACES_BUCKET/cover_images/" \
+          aws s3 sync ./assets/ "s3://$DO_SPACES_BUCKET/assets/" \
             --endpoint-url "https://$DO_SPACES_REGION.digitaloceanspaces.com" \
             --acl public-read \
             --delete

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,6 +24,18 @@ jobs:
         run: "yarn install --frozen-lockfile"
       - name: "Build"
         run: "yarn run build"
+      - name: "Deploy cover images"
+        run: |
+          aws s3 sync ./assets/ "s3://$DO_SPACES_BUCKET/assets/" \
+            --endpoint-url "https://$DO_SPACES_REGION.digitaloceanspaces.com" \
+            --acl public-read \
+            --delete
+        env:
+          DO_SPACES_BUCKET: ${{ vars.DO_SPACES_BUCKET }}
+          DO_SPACES_REGION: ${{ vars.DO_SPACES_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.DO_SPACES_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DO_SPACES_SECRET }}
+          AWS_DEFAULT_REGION: "us-east-1"
       - name: "Deploy"
         run: "yarn run diff && yarn run deploy"
         env:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,6 +24,18 @@ jobs:
         run: "yarn install --frozen-lockfile"
       - name: "Build"
         run: "yarn run build"
+      - name: "Deploy cover images"
+        run: |
+          aws s3 sync ./cover_images/ "s3://$DO_SPACES_BUCKET/cover_images/" \
+            --endpoint-url "https://$DO_SPACES_REGION.digitaloceanspaces.com" \
+            --acl public-read \
+            --delete
+        env:
+          DO_SPACES_BUCKET: ${{ vars.DO_SPACES_BUCKET }}
+          DO_SPACES_REGION: ${{ vars.DO_SPACES_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.DO_SPACES_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DO_SPACES_SECRET }}
+          AWS_DEFAULT_REGION: "us-east-1"
       - name: "Deploy"
         run: "yarn run diff && yarn run deploy"
         env:


### PR DESCRIPTION
Pushes all images in `games/cover_images` onto a DO bucket with `--delete`.

Blocks #320 