### PR TITLE
Revert "Add Inscryption XBox Gamepass to Ecosystem"

### DIFF
--- a/games/data/generated/inscryption.yml
+++ b/games/data/generated/inscryption.yml
@@ -17,8 +17,6 @@ r2modman:
     distributions:
       - platform: "steam"
         identifier: "1092790"
-      - platform: "xbox-game-pass"
-        identifier: "DevolverDigital.Inscryption"
       - platform: "other"
         identifier: null
     settingsIdentifier: "Inscryption"


### PR DESCRIPTION
Reverts thunderstore-io/ecosystem-schema#322

Inscryption on gamepass is x64 while the version on steam is x86. The BPX version that we host does not work on x64, so this is unfortunately broken. Reverting. 