### PR TITLE
Update Sledding Game Steam app ID and install paths

### DIFF
--- a/games/data/sledding-game.yml
+++ b/games/data/sledding-game.yml
@@ -8,11 +8,11 @@ r2modman:
   - gameInstanceType: "game"
     distributions:
       - platform: "steam"
-        identifier: "4029310"
-    steamFolderName: "Sledding Game Demo"
-    dataFolderName: "Sledding Game Demo_Data"
+        identifier: "3438850"
+    steamFolderName: "Sledding Game"
+    dataFolderName: "Sledding Game"
     exeNames:
-      - "Sledding Game Demo.exe"
+      - "Sledding Game.exe"
     packageLoader: "recursive-melonloader"
     meta:
       displayName: "Sledding Game"


### PR DESCRIPTION
Updates the r2modman Steam distribution for Sledding Game from the demo (4029310) to the full release (3438850), and aligns \steamFolderName\, \dataFolderName\, and \exeNames\ with the non-demo install.

Made with [Cursor](https://cursor.com)