### PR TITLE
Migrate Silksong to community-owned BepInExPack

### DIFF
--- a/games/misc/modloader-packages.yml
+++ b/games/misc/modloader-packages.yml
@@ -211,7 +211,7 @@
 - packageId: "BepInEx-BepInExPack_Patapon"
   rootFolder: "BepInExPack"
   loader: "bepinex"
-- packageId: "BepInEx-BepInExPack_Silksong"
+- packageId: "silksong_modding-BepInExPack_Silksong"
   rootFolder: "BepInExPack"
   loader: "bepinex"
 - packageId: "ResoniteModding-BepisLoader"


### PR DESCRIPTION
We are migrating away from the BepInEx-owned BepInExPack to a community-owned version to simplify our ability to do future updates. For this instance we have only made some config changes but we expect to fork/make code changes in the future.

We're coordinating this replacement with 753 to replace the BepInEx-owned copy with an empty package that depends on this to reduce downtime for mods that have an existing dependency; once it is merged we will start advising people to update their dependencies