### PR TITLE
Add AI Generated Tag to: Hytale, The Ouroboros King, and TCG Card Shop Simulator

### DIFF
--- a/games/data/hytale.yml
+++ b/games/data/hytale.yml
@@ -36,6 +36,8 @@ thunderstore:
       label: "Combos"
     misc:
       label: "Misc"
+    ai-generated:
+      label: "AI Generated"
   sections:
     mods:
       name: "Mods"

--- a/games/data/tcg-card-shop-simulator.yml
+++ b/games/data/tcg-card-shop-simulator.yml
@@ -53,6 +53,8 @@ thunderstore:
           label: "0.66 Branch"
         manual-dependencies:
           label: "Requires Manual Dependencies"
+        ai-generated:
+          label: "AI Generated"
   sections:
     main:
       name: "Main Branch"

--- a/games/data/the-ouroboros-king.yml
+++ b/games/data/the-ouroboros-king.yml
@@ -19,6 +19,8 @@ thunderstore:
       label: "Libraries"
     misc:
       label: "Misc"
+    ai-generated:
+      label: "AI Generated"
   sections:
     mods:
       name: "Mods"


### PR DESCRIPTION
This is aimed at ensuring content creators disclose AI Usage within their Packages for these three games which I help setup and am apart of the community of.

If you can please also add the tag to: Inscryption, as I cannot do that one myself from what I am aware.