### PR TITLE
Remove discordUrl from sons-of-the-forest.yml

### DIFF
--- a/games/data/sons-of-the-forest.yml
+++ b/games/data/sons-of-the-forest.yml
@@ -33,4 +33,3 @@ thunderstore:
     modpacks:
       name: "Modpacks"
       requireCategories: ["modpacks"]
-  discordUrl: "https://discord.gg/vb43H9pmx9"


### PR DESCRIPTION
Remove discordUrl from sons-of-the-forest.yml due to it being abandoned and unmoderated